### PR TITLE
trivial: spelling fixes

### DIFF
--- a/docs/mpfr.rst
+++ b/docs/mpfr.rst
@@ -113,7 +113,7 @@ Context Attributes
     result. If the value is ``Default``, then the value of real_prec is used.
 
 **round**
-    There are five rounding modes availble to *mpfr* types:
+    There are five rounding modes available to *mpfr* types:
 
     ``RoundAwayZero``
         The result is rounded away from 0.0.

--- a/docs/mpz.rst
+++ b/docs/mpz.rst
@@ -241,7 +241,7 @@ mpz Functions
 
 **is_prime(...)**
     is_prime(x[, n=25]) returns True if *x* is **probably** prime. False
-    is returned if *x* is definately composite. *x* is checked for small
+    is returned if *x* is definitely composite. *x* is checked for small
     divisors and up to *n* Miller-Rabin tests are performed. The actual tests
     performed may vary based on version of GMP or MPIR used.
 

--- a/src/gmpy2_mpz_misc.c
+++ b/src/gmpy2_mpz_misc.c
@@ -1315,7 +1315,7 @@ GMPy_MPZ_Method_IsPower(PyObject *self, PyObject *other)
 PyDoc_STRVAR(GMPy_doc_mpz_function_is_prime,
 "is_prime(x[, n=25]) -> bool\n\n"
 "Return True if x is _probably_ prime, else False if x is\n"
-"definately composite. x is checked for small divisors and up\n"
+"definitely composite. x is checked for small divisors and up\n"
 "to n Miller-Rabin tests are performed.");
 
 static PyObject *
@@ -1360,7 +1360,7 @@ GMPy_MPZ_Function_IsPrime(PyObject *self, PyObject *args)
 PyDoc_STRVAR(GMPy_doc_mpz_method_is_prime,
 "x.is_prime([n=25]) -> bool\n\n"
 "Return True if x is _probably_ prime, else False if x is\n"
-"definately composite. x is checked for small divisors and up\n"
+"definitely composite. x is checked for small divisors and up\n"
 "to n Miller-Rabin tests are performed.");
 
 static PyObject *


### PR DESCRIPTION
These typos were found and reported by Lintian in the Debian packaging
for gmpy. This patch fixes them.  Although these are not super
important, they will make it easier to see real warnings/issues with
a cleaner Lintian page.

Here's the relevant Lintian page:
https://lintian.debian.org/full/martin@martingkelly.com.html