### PR TITLE
check for __mpz__ and __mpq__ in New

### DIFF
--- a/src/gmpy2_cache.c
+++ b/src/gmpy2_cache.c
@@ -148,6 +148,10 @@ GMPy_MPZ_NewInit(PyTypeObject *type, PyObject *args, PyObject *keywds)
             return (PyObject*)GMPy_MPZ_From_PyStr(n, base, context);
         }
 
+        if (PyObject_HasAttrString(n, "__mpz__")) {
+             return (PyObject*) PyObject_CallMethod(n, "__mpz__", NULL);
+        }
+
         /* Try converting to integer. */
         temp = PyNumber_Long(n);
         if (temp) {
@@ -434,11 +438,16 @@ GMPy_MPQ_NewInit(PyTypeObject *type, PyObject *args, PyObject *keywds)
         return (PyObject*)GMPy_MPQ_From_PyStr(n, base, context);
     }
 
-    /* Handle 1 argument. It must be non-complex number. */
+    /* Handle 1 argument. It must be non-complex number or an object with a __mpq__ method. */
     if (argc == 1) {
         if (IS_REAL(n)) {
             return (PyObject*)GMPy_MPQ_From_Number(n, context);
         }
+
+        if (PyObject_HasAttrString(n, "__mpq__")) {
+             return (PyObject*) PyObject_CallMethod(n, "__mpq__", NULL);
+        }
+
     }
 
     /* Handle 2 arguments. Both arguments must be integer or rational. */


### PR DESCRIPTION
This would allow any object to implement their own conversion to gmpy2. The branch just make `gmpy2.mpz(a)` so that it calls `a.__mpz__()` when the method exists (and similar for `mpq`). With the branch applied one can do

    >>> class A:
    ...    def __mpz__(self):
    ...        import gmpy2
    ...        return gmpy2.mpz('42')
    ...    def __mpq__(self):
    ...        import gmpy2
    ...        return gmpy2.mpq('13/12')
    >>> import gmpy2
    >>> gmpy2.mpq(A())
    mpq(13,12)
    >>> gmpy2.mpz(A())
    mpz(42)

(fixes issue #123)