### PR TITLE
add type checkers in gmpy.pxd

### DIFF
--- a/src/gmpy2.pxd
+++ b/src/gmpy2.pxd
@@ -84,6 +84,18 @@ cdef extern from "gmpy2/gmpy2.h":
     # access to the mpc_t field of a gmpy2 mpc
     cdef mpc_t MPC(MPC_Object *)
 
+    # check if "param" is a MPZ_Object
+    cdef bint MPZ_Check(PyObject *)
+
+    # check if "param" is a MPQ_Object
+    cdef bint MPQ_Check(PyObject *)
+
+    # check if "param" is a MPFR_Object
+    cdef bint MPFR_Check(PyObject *)
+
+    # check if "param" is a MPC_Object
+    cdef bint MPC_Check(PyObject *)
+
 # Build a gmpy2 mpz from a gmp mpz
 cdef inline GMPy_MPZ_From_mpz(mpz_srcptr z):
     cdef MPZ_Object * res = GMPy_MPZ_New(NULL)

--- a/test_cython/runtests.py
+++ b/test_cython/runtests.py
@@ -35,7 +35,9 @@ try:
     old_path = os.getcwd()
     tempdir_path = tempfile.mkdtemp()
 
-    os.chdir(os.path.dirname(__file__))
+    dirname = os.path.dirname(__file__)
+    if dirname != '':
+        os.chdir(dirname)
     copy_tree('./', tempdir_path)
     os.chdir(tempdir_path)
 

--- a/test_cython/test_cython.pyx
+++ b/test_cython/test_cython.pyx
@@ -18,7 +18,18 @@ mpz_set_si(MPZ(<MPZ_Object *> y), 2)
 z = x + y + 1  # python operation!
 assert z == 6
 
+# Checktypes functions with a MPZ_Object
 assert MPZ_Check(<PyObject *>x)
+assert not MPQ_Check(<PyObject *>x)
+assert not MPC_Check(<PyObject *>x)
+assert not MPFR_Check(<PyObject *>x)
+
+# Checktypes functions with a python integer
+i=5
+assert not MPZ_Check(<PyObject *>i)
+assert not MPQ_Check(<PyObject *>i)
+assert not MPC_Check(<PyObject *>i)
+assert not MPFR_Check(<PyObject *>i)
 
 x = <object> GMPy_MPQ_New(NULL)
 y = <object> GMPy_MPQ_New(NULL)
@@ -29,6 +40,8 @@ mpq_set_si(MPQ(<MPQ_Object *> y), -3, 7)
 z = x + y - 1 # python operation!
 assert 28 * z == -33
 
-assert MPQ_Check(<PyObject *>y)
-
-
+# Checktypes functions with a MPZ_Object
+assert not MPZ_Check(<PyObject *>x)
+assert MPQ_Check(<PyObject *>x)
+assert not MPC_Check(<PyObject *>x)
+assert not MPFR_Check(<PyObject *>x)

--- a/test_cython/test_cython.pyx
+++ b/test_cython/test_cython.pyx
@@ -1,7 +1,6 @@
 # distutils: libraries = gmp
 from __future__ import print_function
 from gmpy2 cimport *
-from cpython.object cimport PyObject
 
 import_gmpy2()
 

--- a/test_cython/test_cython.pyx
+++ b/test_cython/test_cython.pyx
@@ -1,6 +1,7 @@
 # distutils: libraries = gmp
 from __future__ import print_function
 from gmpy2 cimport *
+from cpython.object cimport PyObject
 
 import_gmpy2()
 
@@ -18,6 +19,8 @@ mpz_set_si(MPZ(<MPZ_Object *> y), 2)
 z = x + y + 1  # python operation!
 assert z == 6
 
+assert MPZ_Check(<PyObject *>x)
+
 x = <object> GMPy_MPQ_New(NULL)
 y = <object> GMPy_MPQ_New(NULL)
 
@@ -26,3 +29,7 @@ mpq_set_si(MPQ(<MPQ_Object *> y), -3, 7)
 
 z = x + y - 1 # python operation!
 assert 28 * z == -33
+
+assert MPQ_Check(<PyObject *>y)
+
+


### PR DESCRIPTION
- add type checkers in gmpy.pxd
- add some tests in cython test suite
- Fix a bug, causing runtest.py to crash
if called from test_cython directory

related to issue #139 