### PR TITLE
Change --prefix to --shared in the README

### DIFF
--- a/README
+++ b/README
@@ -80,11 +80,11 @@ versions of GMP, MPFR, and MPC do not need to be installed the system library
 directories. The prefix directory is added to the beginning of the directories
 that are checked so it will be found first.
 
-    $ python setup.py install --prefix=/home/case/local
+    $ python setup.py install --shared=/home/case/local
 
 If you get a "permission denied" error message, you may need to use:
 
-    $ python setup.py build --prefix=/home/case/local
-    $ sudo python setup.py install --prefix=/home/case/local
+    $ python setup.py build --shared=/home/case/local
+    $ sudo python setup.py install --shared=/home/case/local
 
 


### PR DESCRIPTION
According to [this](https://github.com/aleaxit/gmpy/blob/c9e086e16d040d86a955900e4cd7593dadfab3f1/setup.py#L208) it's the "--shared" parameter what counts, not "--prefix". 
At least that was the reason I wasn't able to install the package.