### PR TITLE
Bug fix : mpq floor division #156

### DIFF
--- a/src/gmpy2_floordiv.c
+++ b/src/gmpy2_floordiv.c
@@ -222,7 +222,7 @@ GMPy_Rational_FloorDiv(PyObject *x, PyObject *y, CTXT_Object *context)
         }
 
         mpq_div(tempq->q, tempx->q, tempy->q);
-        mpz_fdiv_q(result->z, mpq_numref(tempx->q), mpq_denref(tempy->q));
+        mpz_fdiv_q(result->z, mpq_numref(tempq->q), mpq_denref(tempq->q));
         Py_DECREF((PyObject*)tempx);
         Py_DECREF((PyObject*)tempy);
         Py_DECREF((PyObject*)tempq);

--- a/test/test_mpq.txt
+++ b/test/test_mpq.txt
@@ -109,6 +109,10 @@ Test division
     mpz(0)
     >>> 0/a
     mpq(0,1)
+    >>> mpq(355, 113) // 2
+    mpz(1)
+    >>> mpq(355, 113) // mpz(2)
+    mpz(1)
 
 Test modulo
 -----------


### PR DESCRIPTION
- Fix this bug. Appear when one of the parameters are not an MPQ (PyLong or MPZ for exemple).
- Add two test for these cases. 
- Fix needed for issue #146 