### PR TITLE
Add explicit cast to silence warnings on win64 platform

### DIFF
--- a/src/gmpy2_convert_utils.c
+++ b/src/gmpy2_convert_utils.c
@@ -124,7 +124,7 @@ GMPy_Integer_AsLongAndError(PyObject *vv, int *error)
 
     if (CHECK_MPZANY(vv)) {
         if (mpz_fits_slong_p(MPZ(vv))) {
-            res = mpz_get_si(MPZ(vv));
+            res = (long) mpz_get_si(MPZ(vv));
         }
         else {
             *error = mpz_sgn(MPZ(vv));
@@ -192,7 +192,7 @@ GMPy_Integer_AsUnsignedLongAndError(PyObject *vv, int *error)
 
     if (CHECK_MPZANY(vv)) {
         if (mpz_fits_ulong_p(MPZ(vv))) {
-            res = mpz_get_ui(MPZ(vv));
+            res = (unsigned long) mpz_get_ui(MPZ(vv));
         }
         else {
             *error = mpz_sgn(MPZ(vv));

--- a/src/gmpy2_mpmath.c
+++ b/src/gmpy2_mpmath.c
@@ -255,7 +255,6 @@ Pympz_mpmath_create(PyObject *self, PyObject *args)
             prec = GMPy_Integer_AsMpBitCntAndError(PyTuple_GET_ITEM(args, 2), &error);
             if (error)
                 return NULL;
-            prec = ABS(prec);
         case 2:
             exp = PyTuple_GET_ITEM(args, 1);
         case 1:

--- a/src/gmpy2_pow.c
+++ b/src/gmpy2_pow.c
@@ -134,7 +134,7 @@ GMPy_Integer_Pow(PyObject *b, PyObject *e, PyObject *m, CTXT_Object *context)
             goto err;
         }
 
-        el = mpz_get_ui(tempe->z);
+        el = (unsigned long) mpz_get_ui(tempe->z);
         mpz_pow_ui(result->z, tempb->z, el);
         goto done;
     }
@@ -233,7 +233,7 @@ GMPy_Rational_Pow(PyObject *base, PyObject *exp, PyObject *mod, CTXT_Object *con
             Py_DECREF((PyObject*)tempez);
             return NULL;
         }
-        tempexp = mpz_get_si(tempez->z);
+        tempexp = (long) mpz_get_si(tempez->z);
 
         if (tempexp == 0) {
             mpq_set_si(resultq->q, 1, 1);


### PR DESCRIPTION
Add explicit cast to silence warnings on win64 platform.
For the four case in files gmpy2_convert_utils.c and gmpy2_convert_utils.c(195) where overflow are implossible. 
Issue #146 