### PR TITLE
Fix win64 overflow for gmpy2_add(290) and gmpy2_add(347)

### DIFF
--- a/src/gmpy2_add.c
+++ b/src/gmpy2_add.c
@@ -56,6 +56,10 @@
  * is returned and an exception is set. If either x or y can't be converted
  * into an mpz, Py_NotImplemented is returned.
  */
+#ifndef SIGNED_FITS_SLONG
+#define SIGNED_FITS_SLONG(x)  ((x >= LONG_MIN && x <= LONG_MAX) ? 1 : 0)
+#endif
+
 
 static PyObject *
 GMPy_Integer_Add(PyObject *x, PyObject *y, CTXT_Object *context)
@@ -283,7 +287,7 @@ GMPy_Real_Add(PyObject *x, PyObject *y, CTXT_Object *context)
             int error;
             native_si temp = GMPy_Integer_AsNative_siAndError(y, &error);
 
-            if (!error) {
+            if (!error && SIGNED_FITS_SLONG(temp)) {
                 mpfr_clear_flags();
                 SET_MPFR_WAS_NAN(context, x);
 
@@ -340,7 +344,7 @@ GMPy_Real_Add(PyObject *x, PyObject *y, CTXT_Object *context)
             int error;
             native_si temp = GMPy_Integer_AsNative_siAndError(x, &error);
 
-            if (!error) {
+            if (!error && SIGNED_FITS_SLONG(temp)) {
                 mpfr_clear_flags();
                 SET_MPFR_WAS_NAN(context, y);
 

--- a/src/gmpy2_add.c
+++ b/src/gmpy2_add.c
@@ -291,7 +291,7 @@ GMPy_Real_Add(PyObject *x, PyObject *y, CTXT_Object *context)
                 mpfr_clear_flags();
                 SET_MPFR_WAS_NAN(context, x);
 
-                result->rc = mpfr_add_si(result->f, MPFR(x), temp, GET_MPFR_ROUND(context));
+                result->rc = mpfr_add_si(result->f, MPFR(x), (long)temp, GET_MPFR_ROUND(context));
                 goto done;
             }
             else {
@@ -348,7 +348,7 @@ GMPy_Real_Add(PyObject *x, PyObject *y, CTXT_Object *context)
                 mpfr_clear_flags();
                 SET_MPFR_WAS_NAN(context, y);
 
-                result->rc = mpfr_add_si(result->f, MPFR(y), temp, GET_MPFR_ROUND(context));
+                result->rc = mpfr_add_si(result->f, MPFR(y), (long)temp, GET_MPFR_ROUND(context));
                 goto done;
             }
             else {

--- a/test/test_gmpy2_add.txt
+++ b/test/test_gmpy2_add.txt
@@ -157,6 +157,10 @@ mpfr('2.0')
 True
 >>> (1 << 100) + mpfr(0) == mpfr('1p100', base=2)
 True
+>>> gmpy2.add(2147483648, mpfr(3))
+mpfr('2147483651.0')
+>>> gmpy2.add(mpfr(3), 2147483648)
+mpfr('2147483651.0')
 
 Test complex operations
 -----------------------


### PR DESCRIPTION
- related to issue #146 
- bug append on winx64 when you call add(mpfr(x), y) or add(y, mpfr(x)) with y > 2147483647
- add two doctest to test the fix