### PR TITLE
gmpy2_cache.c : Fix issue #173

### DIFF
--- a/src/gmpy2_cache.c
+++ b/src/gmpy2_cache.c
@@ -150,14 +150,17 @@ GMPy_MPZ_NewInit(PyTypeObject *type, PyObject *args, PyObject *keywds)
         }
 
         if (PyObject_HasAttrString(n, "__mpz__")) {
-             out = (PyObject*) PyObject_CallMethod(n, "__mpz__", NULL);
-             if (!MPZ_Check(out)) {
-                 PyErr_Format(PyExc_TypeError,
-                              "object of type '%.200s' can not be interpreted as mpz",
-                              out->ob_type->tp_name);
-                 return NULL;
-             }
-             return out;
+            out = (PyObject *) PyObject_CallMethod(n, "__mpz__", NULL);
+
+            if (out == NULL)
+                return out;
+            if (!MPZ_Check(out)) {
+                PyErr_Format(PyExc_TypeError,
+                             "object of type '%.200s' can not be interpreted as mpz",
+                             out->ob_type->tp_name);
+                return NULL;
+            }
+            return out;
         }
 
         /* Try converting to integer. */
@@ -455,18 +458,20 @@ GMPy_MPQ_NewInit(PyTypeObject *type, PyObject *args, PyObject *keywds)
     /* Handle 1 argument. It must be non-complex number or an object with a __mpq__ method. */
     if (argc == 1) {
         if (IS_REAL(n)) {
-            return (PyObject*)GMPy_MPQ_From_Number(n, context);
+            return (PyObject *) GMPy_MPQ_From_Number(n, context);
         }
 
         if (PyObject_HasAttrString(n, "__mpq__")) {
-             out = (PyObject*) PyObject_CallMethod(n, "__mpq__", NULL);
-             if (!MPQ_Check(out)) {
-                 PyErr_Format(PyExc_TypeError,
-                              "object of type '%.200s' can not be interpreted as mpq",
-                              out->ob_type->tp_name);
-                 return NULL;
-             }
-             return out;
+            out = (PyObject *) PyObject_CallMethod(n, "__mpq__", NULL);
+            if (out == NULL)
+                return out;
+            if (!MPQ_Check(out)) {
+                PyErr_Format(PyExc_TypeError,
+                             "object of type '%.200s' can not be interpreted as mpq",
+                             out->ob_type->tp_name);
+                return NULL;
+            }
+            return out;
         }
 
     }
@@ -663,14 +668,17 @@ GMPy_MPFR_NewInit(PyTypeObject *type, PyObject *args, PyObject *keywds)
     }
 
     if (PyObject_HasAttrString(arg0, "__mpfr__")) {
-         out = (PyObject*) PyObject_CallMethod(arg0, "__mpfr__", NULL);
-         if (!MPFR_Check(out)) {
-             PyErr_Format(PyExc_TypeError,
-                          "object of type '%.200s' can not be interpreted as mpfr",
-                          out->ob_type->tp_name);
-             return NULL;
-         }
-         return out;
+        out = (PyObject *) PyObject_CallMethod(arg0, "__mpfr__", NULL);
+
+        if(out == NULL)
+            return out;
+        if (!MPFR_Check(out)) {
+            PyErr_Format(PyExc_TypeError,
+                         "object of type '%.200s' can not be interpreted as mpfr",
+                         out->ob_type->tp_name);
+            return NULL;
+        }
+        return out;
     }
 
     TYPE_ERROR("mpfr() requires numeric or string argument");
@@ -963,6 +971,8 @@ GMPy_MPC_NewInit(PyTypeObject *type, PyObject *args, PyObject *keywds)
 
     if (PyObject_HasAttrString(arg0, "__mpc__")) {
         out = (PyObject*) PyObject_CallMethod(arg0, "__mpc__", NULL);
+        if(out == NULL)
+            return out;
         if (!MPC_Check(out)) {
             PyErr_Format(PyExc_TypeError,
                          "object of type '%.200s' can not be interpreted as mpc",

--- a/test/test_gmpy2_constructors.txt
+++ b/test/test_gmpy2_constructors.txt
@@ -14,10 +14,16 @@ Test constructors via special methods
 ...     def __mpc__(self): return 'hello'
 >>> class C:
 ...     pass
+>>> class D:
+...     def __mpz__(self): raise TypeError
+...     def __mpq__(self): raise TypeError
+...     def __mpfr__(self): raise TypeError
+...     def __mpc__(self): raise TypeError
 
 >>> a = A()
 >>> b = B()
 >>> c = C()
+>>> d = D()
 
 Test mpz conversion
 -------------------
@@ -94,3 +100,23 @@ TypeError: object of type 'str' can not be interpreted as mpc
 Traceback (most recent call last):
 ...
 TypeError: mpc() requires numeric or string argument
+
+Test special methods raising errors
+--------------------
+>>> mpz(d)
+Traceback (most recent call last):
+...
+TypeError
+>>> mpq(d)
+Traceback (most recent call last):
+...
+TypeError
+>>> mpfr(d)
+Traceback (most recent call last):
+...
+TypeError
+>>> mpc(d)
+Traceback (most recent call last):
+...
+TypeError
+


### PR DESCRIPTION
issue #173 
- Fix segfault when objects have custom `__mpz__`, `__mpq__`,
`__mpfr__` or `__mpc__` methods raising errors.

- add doctests for these cases.