### PR TITLE
Cleanup

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -45,7 +45,7 @@ install:
 build: off
 
 test_script:
-    - cmd: python setup.py install --mpir --static=%CONDA_PREFIX%\Library
+    - cmd: python setup.py install build_ext --mpir --include-dirs=%CONDA_PREFIX%\Library\include --library-dirs=%CONDA_PREFIX%\Library\lib
     - cmd: cd test && python runtests.py
     - cmd: cd ..
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -45,7 +45,7 @@ install:
 build: off
 
 test_script:
-    - cmd: python setup.py install build_ext --mpir --include-dirs=%CONDA_PREFIX%\Library\include --library-dirs=%CONDA_PREFIX%\Library\lib
+    - cmd: python setup.py install build_ext --mpir -I%CONDA_PREFIX%\Library\include -L%CONDA_PREFIX%\Library\lib
     - cmd: cd test && python runtests.py
     - cmd: cd ..
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ install:
       echo ""
       echo "Installing latex"
       port install texlive texlive-latex-extra
-      python setup.py install build_ext --include-dirs=$CONDA_PREFIX/include --library-dirs=$CONDA_PREFIX/lib ;
+      python setup.py install build_ext -I$CONDA_PREFIX/include -L$CONDA_PREFIX/lib ;
     else # Linux
       export PATH="/usr/lib/ccache:$PATH"
       ccache -M 256M && ccache -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ install:
       echo ""
       echo "Installing latex"
       port install texlive texlive-latex-extra
-      python setup.py install --shared=$CONDA_PREFIX;
+      python setup.py install build_ext --include-dirs=$CONDA_PREFIX/include --library-dirs=$CONDA_PREFIX/lib ;
     else # Linux
       export PATH="/usr/lib/ccache:$PATH"
       ccache -M 256M && ccache -s

--- a/setup.py
+++ b/setup.py
@@ -95,10 +95,6 @@ class gmpy_build_ext(build_ext):
 
     def doit(self):
         # Find the directory specfied for non-standard library location.
-        search_dirs = []
-        static = False
-        msys2 = False
-        mpir = False
 
         defines = []
 
@@ -137,7 +133,7 @@ class gmpy_build_ext(build_ext):
         if windows and not self.msys2:
             self.extensions[0].extra_link_args.append('/MANIFEST')
             defines.append(("MPIR", 1))
-            if not static:
+            if not self.static:
                 defines.append(("MSC_USE_DLL", None))
 
         self.extensions[0].define_macros.extend(defines)


### PR DESCRIPTION
I cleaned up setup.py a bit and now standard things like extra include-dirs should be given to build_ext. New help is,
```
isuru@dell:~/projects/gmpy$ python setup.py build_ext --help
Common commands: (see '--help-commands' for more)

  setup.py build      will build the package underneath 'build/'
  setup.py install    will install the package

Global options:
  --verbose (-v)  run verbosely (default)
  --quiet (-q)    run quietly (turns verbosity off)
  --dry-run (-n)  don't actually do anything
  --help (-h)     show detailed help message
  --no-user-cfg   ignore pydistutils.cfg in your home directory

Options for 'gmpy_build_ext' command:
  --mpir               Build using mpir
  --msys2              Build in msys2 environment
  --gcov               configure GCC to collect code coverage data for testing
                       purposes
  --fast               depend on MPFR and MPC internal implementations details
  --vector             include the vector_XXX() functions; they are unstable
                       and under active development
  --shared             Build using shared libraries
  --static             Build using static libraries
  --build-lib (-b)     directory for compiled extension modules
  --build-temp (-t)    directory for temporary files (build by-products)
  --plat-name (-p)     platform name to cross-compile for, if supported
                       (default: linux-x86_64)
  --inplace (-i)       ignore build-lib and put compiled extensions into the
                       source directory alongside your pure Python modules
  --include-dirs (-I)  list of directories to search for header files
                       (separated by ':')
  --define (-D)        C preprocessor macros to define
  --undef (-U)         C preprocessor macros to undefine
  --libraries (-l)     external C libraries to link with
  --library-dirs (-L)  directories to search for external C libraries
                       (separated by ':')
  --rpath (-R)         directories to search for shared C libraries at runtime
  --link-objects (-O)  extra explicit link objects to include in the link
  --debug (-g)         compile/link with debugging information
  --force (-f)         forcibly build everything (ignore file timestamps)
  --compiler (-c)      specify the compiler type
  --swig-cpp           make SWIG create C++ files (default is C)
  --swig-opts          list of SWIG command line options
  --swig               path to the SWIG executable
  --user               add user include, library and rpath
  --help-compiler      list available compilers

usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: setup.py --help [cmd1 cmd2 ...]
   or: setup.py --help-commands
   or: setup.py cmd --help
```