### PR TITLE
Fix for mpc precision inconsistency issue #179

### DIFF
--- a/src/gmpy2_mpc_misc.c
+++ b/src/gmpy2_mpc_misc.c
@@ -393,7 +393,10 @@ GMPy_MPC_GetImag_Attrib(MPC_Object *self, void *closure)
 
     CHECK_CONTEXT(context);
 
-    if ((result = GMPy_MPFR_New(0, context))) {
+    mpfr_prec_t rprec = 0, iprec = 0;
+    mpc_get_prec2(&rprec, &iprec, self->c);
+
+    if ((result = GMPy_MPFR_New(iprec, context))) {
         result->rc = mpc_imag(result->f, self->c, GET_MPFR_ROUND(context));
         _GMPy_MPFR_Cleanup(&result, context);
     }
@@ -410,7 +413,10 @@ GMPy_MPC_GetReal_Attrib(MPC_Object *self, void *closure)
 
     CHECK_CONTEXT(context);
 
-    if ((result = GMPy_MPFR_New(0, context))) {
+    mpfr_prec_t rprec = 0, iprec = 0;
+    mpc_get_prec2(&rprec, &iprec, self->c);
+
+    if ((result = GMPy_MPFR_New(rprec, context))) {
         result->rc = mpc_real(result->f, self->c, context->ctx.mpfr_round);
         _GMPy_MPFR_Cleanup(&result, context);
     }

--- a/test/test_mpc.txt
+++ b/test/test_mpc.txt
@@ -199,4 +199,12 @@ False
 >>> G.is_finite(mpc("inf+3j"))
 False
 
-
+Test mpc misc
+-------------
+>>> c=mpc('67+87j', precision=70)
+>>> c.precision
+(70, 70)
+>>> c.real.precision
+70
+>>> c.imag.precision
+70

--- a/test/test_mpc.txt
+++ b/test/test_mpc.txt
@@ -208,3 +208,13 @@ Test mpc misc
 70
 >>> c.imag.precision
 70
+>>> c = mpc('42e56+42.909j', precision=(45,300))
+>>> c.precision
+(45, 300)
+>>> c.real.precision
+45
+>>> c.imag.precision
+300
+>>> x = mpc("1.3142123+4.3e-1001j", precision=(70,37))
+>>> mpc(x.real, x.imag, precision=(70,37)) == x
+True


### PR DESCRIPTION
Fix for issue #179 
- .real and .imag mpfr now return the same precision as their mpc
- add doctests for these cases.