### PR TITLE
travis.yml: Use xenial instead of trusty for  linux tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,17 +12,17 @@ notifications:
 matrix:
   include:
     - os: linux
-      dist: trusty
+      dist: xenial
       language: python
       python: 2.7
 
     - os: linux
-      dist: trusty
+      dist: xenial
       language: python
       python: 3.5
 
     - os: linux
-      dist: trusty
+      dist: xenial
       language: python
       python: 3.6
 


### PR DESCRIPTION
Trusty support will end next month.
Using xenial for test also fix issue #213 