### PR TITLE
Fix issue #214 Allow arithmetic operation between gmpy2 numbers and custom objects

### DIFF
--- a/docs/conversion.rst
+++ b/docs/conversion.rst
@@ -1,0 +1,54 @@
+Conversion methods and gmpy2's numbers
+======================================
+
+Conversion methods
+------------------
+
+A python object could interact with gmpy2 if it implements one the following methods:
+
+- **__mpz__** : return an object of <type 'mpz'>.
+- **__mpq__** : return an object of <type 'mpq'>.
+- **__mpfr__** : return an object of <type 'mpfr'>.
+- **__mpc__** : return an object of <type 'mpc'>.
+
+| Implementing on of these methods allow gmpy2 to convert a python object into a gmpy2 type.
+| Example::
+
+    >>> from gmpy2 import mpz
+    >>> class CustInt:
+    ...     def __init__(self, x):
+    ...             self.x = x
+    ...     def __mpz__(self):
+    ...             return mpz(self.x)
+    ...
+    >>> ci = CustInt(5)
+    >>> z = mpz(ci); z
+    mpz(5)
+    >>> type(z)
+    <type 'mpz'>
+
+Arithmetic operations
+---------------------
+
+| gmpy2 allow arithmetic operations between gmpy2 numbers and objects with conversion methods.
+| Operation with object that implements floating conversion and exact conversion methods are not supported.
+| That means that only the following cases are supported:
+
+- An integer type have to implement **__mpz__**
+- A rational type have to implement **__mpq__** and can implement **__mpz__**
+- A real type have to implement **__mpfr__**
+- A complex type have to implement **__mpc__** and can implement **__mpfr__**
+
+Examples::
+
+    >>> from gmpy2 import mpz, mpq, mpfr, mpc
+    >>> class Q:
+    ...     def __mpz__(self): return mpz(1)
+    ...     def __mpq__(self): return mpq(3,2)
+    >>> q = Q()
+    >>> mpz(2) + q
+    mpq(7,2)
+    >>> mpq(1,2) * q
+    mpq(3,4)
+    >>> mpfr(10) * q
+    mpfr('15.0')

--- a/docs/conversion.rst
+++ b/docs/conversion.rst
@@ -4,7 +4,7 @@ Conversion methods and gmpy2's numbers
 Conversion methods
 ------------------
 
-A python object could interact with gmpy2 if it implements one the following methods:
+A python object could interact with gmpy2 if it implements one of the following methods:
 
 - **__mpz__** : return an object of <type 'mpz'>.
 - **__mpq__** : return an object of <type 'mpq'>.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,7 @@ Contents:
    mpfr
    mpc
    cython
+   conversion
    history
 
 Indices and tables

--- a/src/gmpy2_cache.c
+++ b/src/gmpy2_cache.c
@@ -149,7 +149,7 @@ GMPy_MPZ_NewInit(PyTypeObject *type, PyObject *args, PyObject *keywds)
             return (PyObject*)GMPy_MPZ_From_PyStr(n, base, context);
         }
 
-        if (PyObject_HasAttrString(n, "__mpz__")) {
+        if (HAS_MPZ_CONVERSION(n)) {
             out = (PyObject *) PyObject_CallMethod(n, "__mpz__", NULL);
 
             if (out == NULL)
@@ -461,7 +461,7 @@ GMPy_MPQ_NewInit(PyTypeObject *type, PyObject *args, PyObject *keywds)
             return (PyObject *) GMPy_MPQ_From_Number(n, context);
         }
 
-        if (PyObject_HasAttrString(n, "__mpq__")) {
+        if (HAS_MPQ_CONVERSION(n)) {
             out = (PyObject *) PyObject_CallMethod(n, "__mpq__", NULL);
             if (out == NULL)
                 return out;
@@ -645,6 +645,20 @@ GMPy_MPFR_NewInit(PyTypeObject *type, PyObject *args, PyObject *keywds)
         return (PyObject*)GMPy_MPFR_From_PyStr(arg0, base, prec, context);
     }
 
+    if (HAS_MPFR_CONVERSION(arg0)) {
+        out = (PyObject *) PyObject_CallMethod(arg0, "__mpfr__", NULL);
+
+        if(out == NULL)
+            return out;
+        if (!MPFR_Check(out)) {
+            PyErr_Format(PyExc_TypeError,
+                         "object of type '%.200s' can not be interpreted as mpfr",
+                         out->ob_type->tp_name);
+            return NULL;
+        }
+        return out;
+    }
+
     /* A number can only have precision and context as additional arguments. */
     if (IS_REAL(arg0)) {
         if (keywdc || argc > 1) {
@@ -664,20 +678,6 @@ GMPy_MPFR_NewInit(PyTypeObject *type, PyObject *args, PyObject *keywds)
         }
 
         return (PyObject*)GMPy_MPFR_From_Real(arg0, prec, context);
-    }
-
-    if (PyObject_HasAttrString(arg0, "__mpfr__")) {
-        out = (PyObject *) PyObject_CallMethod(arg0, "__mpfr__", NULL);
-
-        if(out == NULL)
-            return out;
-        if (!MPFR_Check(out)) {
-            PyErr_Format(PyExc_TypeError,
-                         "object of type '%.200s' can not be interpreted as mpfr",
-                         out->ob_type->tp_name);
-            return NULL;
-        }
-        return out;
     }
 
     TYPE_ERROR("mpfr() requires numeric or string argument");
@@ -858,6 +858,19 @@ GMPy_MPC_NewInit(PyTypeObject *type, PyObject *args, PyObject *keywds)
         return (PyObject*)GMPy_MPC_From_PyStr(arg0, base, rprec, iprec, context);
     }
 
+    if (HAS_MPC_CONVERSION(arg0)) {
+        out = (PyObject*) PyObject_CallMethod(arg0, "__mpc__", NULL);
+        if(out == NULL)
+            return out;
+        if (!MPC_Check(out)) {
+            PyErr_Format(PyExc_TypeError,
+                         "object of type '%.200s' can not be interpreted as mpc",
+                         out->ob_type->tp_name);
+            return NULL;
+        }
+        return out;
+    }
+
     /* Should special case PyFLoat to avoid double rounding. */
 
     if (IS_REAL(arg0)) {
@@ -966,19 +979,6 @@ GMPy_MPC_NewInit(PyTypeObject *type, PyObject *args, PyObject *keywds)
             result = GMPy_MPC_From_MPC((MPC_Object*)arg0, rprec, iprec, context);
         }
         return (PyObject*)result;
-    }
-
-    if (PyObject_HasAttrString(arg0, "__mpc__")) {
-        out = (PyObject*) PyObject_CallMethod(arg0, "__mpc__", NULL);
-        if(out == NULL)
-            return out;
-        if (!MPC_Check(out)) {
-            PyErr_Format(PyExc_TypeError,
-                         "object of type '%.200s' can not be interpreted as mpc",
-                         out->ob_type->tp_name);
-            return NULL;
-        }
-        return out;
     }
 
     TYPE_ERROR("mpc() requires numeric or string argument");

--- a/src/gmpy2_convert.h
+++ b/src/gmpy2_convert.h
@@ -36,22 +36,34 @@ extern "C" {
 /* The following macros classify the numeric types that are supported by
  * gmpy2.
  */
+#define HAS_MPZ_CONVERSION(x) PyObject_HasAttrString(x, "__mpz__")
+#define HAS_MPQ_CONVERSION(x) PyObject_HasAttrString(x, "__mpq__")
+#define HAS_MPFR_CONVERSION(x) PyObject_HasAttrString(x, "__mpfr__")
+#define HAS_MPC_CONVERSION(x) PyObject_HasAttrString(x, "__mpc__")
+
+#define HAS_STRICT_MPZ_CONVERSION(x) HAS_MPZ_CONVERSION(x) && \
+                                     !HAS_MPQ_CONVERSION(x)
+#define HAS_STRICT_MPFR_CONVERSION(x) HAS_MPFR_CONVERSION(x) && \
+                                      !HAS_MPC_CONVERSION(x)
 
 #ifdef PY2
-#define IS_INTEGER(x) (MPZ_Check(x) || PyInt_Check(x) || PyLong_Check(x) || XMPZ_Check(x))
+#define IS_INTEGER(x) (MPZ_Check(x) || PyInt_Check(x) || \
+                        PyLong_Check(x) || XMPZ_Check(x) || \
+                        HAS_STRICT_MPZ_CONVERSION(x))
 #else
-#define IS_INTEGER(x) (MPZ_Check(x) || PyLong_Check(x) || XMPZ_Check(x))
+#define IS_INTEGER(x) (MPZ_Check(x) || PyLong_Check(x) || \
+                        XMPZ_Check(x) || HAS_STRICT_MPZ_CONVERSION(x))
 #endif
 
 #define IS_FRACTION(x) (!strcmp(Py_TYPE(x)->tp_name, "Fraction"))
 
-#define IS_RATIONAL_ONLY(x) (MPQ_Check(x) || IS_FRACTION(x))
+#define IS_RATIONAL_ONLY(x) (MPQ_Check(x) || IS_FRACTION(x) || HAS_MPQ_CONVERSION(x))
 #define IS_RATIONAL(x) (IS_INTEGER(x) || IS_RATIONAL_ONLY(x))
 
-#define IS_REAL_ONLY(x) (MPFR_Check(x) || PyFloat_Check(x))
+#define IS_REAL_ONLY(x) (MPFR_Check(x) || PyFloat_Check(x) || HAS_STRICT_MPFR_CONVERSION(x))
 #define IS_REAL(x) (IS_RATIONAL(x) || IS_REAL_ONLY(x))
 
-#define IS_COMPLEX_ONLY(x) (MPC_Check(x) || PyComplex_Check(x))
+#define IS_COMPLEX_ONLY(x) (MPC_Check(x) || PyComplex_Check(x) || HAS_MPC_CONVERSION(x))
 #define IS_COMPLEX(x) (IS_REAL(x) || IS_COMPLEX_ONLY(x))
 
 /* Since the macros are used in gmpy2's codebase, these functions are skipped

--- a/src/gmpy2_convert_gmp.c
+++ b/src/gmpy2_convert_gmp.c
@@ -312,6 +312,13 @@ GMPy_MPZ_From_Integer(PyObject *obj, CTXT_Object *context)
     if (XMPZ_Check(obj))
         return GMPy_MPZ_From_XMPZ((XMPZ_Object*)obj, context);
 
+    if (HAS_STRICT_MPZ_CONVERSION(obj)) {
+        result = (MPZ_Object *) PyObject_CallMethod(obj, "__mpz__", NULL);
+
+        if (result != NULL && MPZ_Check(result))
+            return result;
+    }
+
     TYPE_ERROR("cannot convert object to mpz");
     return result;
 }
@@ -994,6 +1001,20 @@ GMPy_MPQ_From_Number(PyObject *obj, CTXT_Object *context)
 
     if (IS_FRACTION(obj))
         return GMPy_MPQ_From_Fraction(obj, context);
+
+    if (HAS_MPQ_CONVERSION(obj)) {
+        MPQ_Object * res = (MPQ_Object *) PyObject_CallMethod(obj, "__mpq__", NULL);
+
+        if (res != NULL && MPQ_Check(res))
+            return res;
+    }
+
+    if (HAS_MPZ_CONVERSION(obj)) {
+        MPZ_Object * res = (MPZ_Object *) PyObject_CallMethod(obj, "__mpz__", NULL);
+
+        if (res != NULL && MPZ_Check(res))
+            return GMPy_MPQ_From_MPZ(res, context);
+    }
 
     TYPE_ERROR("cannot convert object to mpq");
     return NULL;

--- a/src/gmpy2_convert_mpc.c
+++ b/src/gmpy2_convert_mpc.c
@@ -437,6 +437,34 @@ GMPy_MPC_From_Complex(PyObject* obj, mp_prec_t rprec, mp_prec_t iprec,
     if (IS_FRACTION(obj))
         return GMPy_MPC_From_Fraction(obj, rprec, iprec, context);
 
+    if (HAS_MPC_CONVERSION(obj)) {
+        MPC_Object * res = (MPC_Object *) PyObject_CallMethod(obj, "__mpc__", NULL);
+
+        if (res != NULL && MPC_Check(res))
+            return res;
+    }
+
+    if (HAS_MPFR_CONVERSION(obj)) {
+        MPFR_Object * res = (MPFR_Object *) PyObject_CallMethod(obj, "__mpfr__", NULL);
+
+        if (res != NULL && MPFR_Check(res))
+            return GMPy_MPC_From_MPFR(res, rprec, iprec, context);
+    }
+
+    if (HAS_MPQ_CONVERSION(obj)) {
+        MPQ_Object * res = (MPQ_Object *) PyObject_CallMethod(obj, "__mpq__", NULL);
+
+        if (res != NULL && MPQ_Check(res))
+            return GMPy_MPC_From_MPQ(res, rprec, iprec, context);
+    }
+
+    if (HAS_MPZ_CONVERSION(obj)) {
+        MPZ_Object * res = (MPZ_Object *) PyObject_CallMethod(obj, "__mpz__", NULL);
+
+        if (res != NULL && MPZ_Check(res))
+            return GMPy_MPC_From_MPZ(res, rprec, iprec, context);
+    }
+
     TYPE_ERROR("object could not be converted to 'mpc'");
     return NULL;
 }

--- a/src/gmpy2_convert_mpfr.c
+++ b/src/gmpy2_convert_mpfr.c
@@ -437,6 +437,27 @@ GMPy_MPFR_From_Real(PyObject *obj, mp_prec_t prec, CTXT_Object *context)
     if (IS_FRACTION(obj))
         return GMPy_MPFR_From_Fraction(obj, prec, context);
 
+    if (HAS_MPFR_CONVERSION(obj)) {
+        MPFR_Object *res = (MPFR_Object *) PyObject_CallMethod(obj, "__mpfr__", NULL);
+
+        if (res != NULL && MPFR_Check(res))
+            return res;
+    }
+
+    if (HAS_MPQ_CONVERSION(obj)) {
+        MPQ_Object *res = (MPQ_Object *) PyObject_CallMethod(obj, "__mpq__", NULL);
+
+        if (res != NULL && MPQ_Check(res))
+            return GMPy_MPFR_From_MPQ(res, prec, context);
+    }
+
+    if (HAS_MPZ_CONVERSION(obj)) {
+        MPZ_Object *res = (MPZ_Object *) PyObject_CallMethod(obj, "__mpz__", NULL);
+
+        if (res != NULL && MPZ_Check(res))
+            return GMPy_MPFR_From_MPZ(res, prec, context);
+    }
+
     TYPE_ERROR("object could not be converted to 'mpfr'");
     return NULL;
 }

--- a/test/test_gmpy2_add.txt
+++ b/test/test_gmpy2_add.txt
@@ -10,6 +10,20 @@ Test all code in the file gmpy2_add.c.
 >>> a = mpz(123)
 >>> b = mpz(456)
 >>> c = 12345678901234567890
+>>> class Z:
+...     def __mpz__(self): return mpz(1)
+>>> class Q:
+...     def __mpz__(self): return mpz(1)
+...     def __mpq__(self): return mpq(3,2)
+>>> class R:
+...     def __mpfr__(self): return mpfr(1.5)
+>>> class Cx:
+...     def __mpfr__(self): return mpfr(1.5)
+...     def __mpc__(self): return mpc(42,67)
+>>> z = Z()
+>>> q = Q()
+>>> r = R()
+>>> cx = Cx()
 
 Test integer operations
 -----------------------
@@ -40,6 +54,8 @@ mpz(579)
 mpz(-333)
 >>> (-b)+a
 mpz(-333)
+>>> a+z
+mpz(124)
 
 >>> ctx=gmpy2.context()
 >>> ctx.add(a,b) == a+b
@@ -106,6 +122,10 @@ mpq(3,2)
 mpc('1.0+0.0j')
 >>> mpc(0) + mpq(1,1)
 mpc('1.0+0.0j')
+>>> mpq(1,2) + z
+mpq(3,2)
+>>> mpq(1,2) + q
+mpq(2,1)
 
 >>> ctx=gmpy2.context()
 >>> ctx.add(mpq(1,2), mpq(3,2))
@@ -159,6 +179,12 @@ mpfr('2.0')
 True
 >>> (1 << 100) + mpfr(0) == mpfr('1p100', base=2)
 True
+>>> mpfr(1) + z
+mpfr('2.0')
+>>> mpfr(0.5) + q
+mpfr('2.0')
+>>> mpfr(1.5) + r
+mpfr('3.0')
 
 Test complex operations
 -----------------------
@@ -173,4 +199,12 @@ mpc('2.0+2.0j')
 >>> mpc(1,2) + 1+0j
 mpc('2.0+2.0j')
 >>> 1+0j + mpc(1,2)
+mpc('2.0+2.0j')
+>>> mpc(1,2) + cx
+mpc('43.0+69.0j')
+>>> mpc(1,2) + r
+mpc('2.5+2.0j')
+>>> mpc(1,2) + q
+mpc('2.5+2.0j')
+>>> mpc(1,2) + z
 mpc('2.0+2.0j')

--- a/test/test_gmpy2_mul.txt
+++ b/test/test_gmpy2_mul.txt
@@ -10,10 +10,26 @@ Test all code in the file gmpy2_sub.c.
 >>> a = mpz(123)
 >>> b = mpz(456)
 >>> c = 12345678901234567890
+>>> class Z:
+...     def __mpz__(self): return mpz(2)
+>>> class Q:
+...     def __mpz__(self): return mpz(1)
+...     def __mpq__(self): return mpq(3,2)
+>>> class R:
+...     def __mpfr__(self): return mpfr(1.5)
+>>> class Cx:
+...     def __mpfr__(self): return mpfr(1.5)
+...     def __mpc__(self): return mpc(42,67)
+>>> z = Z()
+>>> q = Q()
+>>> r = R()
+>>> cx = Cx()
 
 Test integer operations
 -----------------------
 
+>>> mpz(2) * z
+mpz(4)
 >>> gmpy2.mul(2,1)
 mpz(2)
 
@@ -56,6 +72,10 @@ mpq(-1,2)
 mpc('1.0+0.0j')
 >>> mpc(1,0) * mpq(1,1)
 mpc('1.0+0.0j')
+>>> mpq(1,2) * z
+mpq(1,1)
+>>> mpq(1,2) * q
+mpq(3,4)
 
 >>> ctx=gmpy2.context()
 >>> ctx.mul(mpq(1,2), mpq(3,2))
@@ -109,6 +129,12 @@ mpfr('10.0')
 True
 >>> c * mpfr(1) == mpfr(c)
 True
+>>> mpfr(10) * z
+mpfr('20.0')
+>>> mpfr(10) * q
+mpfr('15.0')
+>>> mpfr(10) * r
+mpfr('15.0')
 >>> mpfr(10) * 'a'
 Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
@@ -134,3 +160,11 @@ mpc('-1.0-2.0j')
 mpc('1.0+2.0j')
 >>> (1+0j) * mpc(1,2)
 mpc('1.0+2.0j')
+>>> mpc(1,2) * z
+mpc('2.0+4.0j')
+>>> mpc(1,2) * q
+mpc('1.5+3.0j')
+>>> mpc(1,2) * r
+mpc('1.5+3.0j')
+>>> mpc(1,2) * cx
+mpc('-92.0+151.0j')

--- a/test/test_gmpy2_sub.txt
+++ b/test/test_gmpy2_sub.txt
@@ -10,6 +10,20 @@ Test all code in the file gmpy2_sub.c.
 >>> a = mpz(123)
 >>> b = mpz(456)
 >>> c = 12345678901234567890
+>>> class Z:
+...     def __mpz__(self): return mpz(2)
+>>> class Q:
+...     def __mpz__(self): return mpz(1)
+...     def __mpq__(self): return mpq(3,2)
+>>> class R:
+...     def __mpfr__(self): return mpfr(1.5)
+>>> class Cx:
+...     def __mpfr__(self): return mpfr(1.5)
+...     def __mpc__(self): return mpc(2,3)
+>>> z = Z()
+>>> q = Q()
+>>> r = R()
+>>> cx = Cx()
 
 Test integer operations
 -----------------------
@@ -40,6 +54,8 @@ mpz(333)
 mpz(579)
 >>> (-b)-a
 mpz(-579)
+>>> a-z
+mpz(121)
 
 >>> gmpy2.sub(2,1)
 mpz(1)
@@ -105,6 +121,10 @@ mpq(-1,2)
 mpc('1.0+0.0j')
 >>> mpc(0) - mpq(1,1)
 mpc('-1.0+0.0j')
+>>> mpq(1,2) - z
+mpq(-3,2)
+>>> mpq(1,2) - q
+mpq(-1,1)
 
 >>> ctx=gmpy2.context()
 >>> ctx.sub(mpq(1,2), mpq(3,2))
@@ -158,6 +178,12 @@ mpfr('9.0')
 True
 >>> (1 << 100) - mpfr(0) == mpfr('1p100', base=2)
 True
+>>> mpfr(10) - z
+mpfr('8.0')
+>>> mpfr(10) - q
+mpfr('8.5')
+>>> mpfr(10) - r
+mpfr('8.5')
 
 Test complex operations
 -----------------------
@@ -173,3 +199,11 @@ mpc('0.0+2.0j')
 mpc('0.0+2.0j')
 >>> 1+0j - mpc(1,2)
 mpc('0.0-2.0j')
+>>> mpc(1,2) - z
+mpc('-1.0+2.0j')
+>>> mpc(1,2) - q
+mpc('-0.5+2.0j')
+>>> mpc(1,2) - r
+mpc('-0.5+2.0j')
+>>> mpc(1,2) - cx
+mpc('-1.0-1.0j')

--- a/test/test_mpc.txt
+++ b/test/test_mpc.txt
@@ -14,6 +14,20 @@ Test mpc elementary operations
 >>> bq = mpq(17,2)
 >>> aj = mpc(1+2j)
 >>> bj = mpc(4+5j)
+>>> class Z:
+...     def __mpz__(self): return mpz(2)
+>>> class Q:
+...     def __mpz__(self): return mpz(1)
+...     def __mpq__(self): return mpq(3,2)
+>>> class R:
+...     def __mpfr__(self): return mpfr(1.5)
+>>> class Cx:
+...     def __mpfr__(self): return mpfr(1.5)
+...     def __mpc__(self): return mpc(3,2)
+>>> z = Z()
+>>> q = Q()
+>>> r = R()
+>>> cx = Cx()
 
 Test addition
 -------------
@@ -98,6 +112,15 @@ mpc('0.008130081300813009+0.016260162601626018j')
 mpc('24.600000000000001-49.200000000000003j')
 >>> aj / 0
 mpc('inf+infj')
+>>> mpc('2.0+2.0j') / z
+mpc('1.0+1.0j')
+>>> mpc('2.0+2.0j') / q
+mpc('1.3333333333333333+1.3333333333333333j')
+>>> mpc('2.0+2.0j') / r
+mpc('1.3333333333333333+1.3333333333333333j')
+>>> mpc(15,15) / cx
+mpc('5.7692307692307692+1.1538461538461537j')
+
 
 Test modulo
 -----------

--- a/test/test_mpfr.txt
+++ b/test/test_mpfr.txt
@@ -23,6 +23,16 @@ Testing of mpfr functionality is split into multiple files.
     >>> a = mpfr("12.34")
     >>> b = mpfr("45.67")
     >>> c = 12345678901234567890
+    >>> class Z:
+    ...     def __mpz__(self): return mpz(2)
+    >>> class Q:
+    ...     def __mpz__(self): return mpz(1)
+    ...     def __mpq__(self): return mpq(1,2)
+    >>> class R:
+    ...     def __mpfr__(self): return mpfr(1.5)
+    >>> z = Z()
+    >>> q = Q()
+    >>> r = R()
 
 Test elementary operations
 ==========================
@@ -142,6 +152,13 @@ Test division
     mpfr('-inf')
     >>> a/b==12.34/45.67
     True
+    >>> mpfr(10) / z
+    mpfr('5.0')
+    >>> mpfr(10) / q
+    mpfr('20.0')
+    >>> mpfr(10) / r
+    mpfr('6.666666666666667')
+
 
 Test modulo
 -----------
@@ -150,6 +167,8 @@ Test modulo
     mpfr('0.33999999999999986')
     >>> 12.34%1
     0.33999999999999986
+    >>> a%z
+    mpfr('0.33999999999999986')
 
 Test divmod
 -----------

--- a/test/test_mpq.txt
+++ b/test/test_mpq.txt
@@ -18,6 +18,13 @@ Testing of mpq functionality is split into multiple files.
     >>> a = mpq(3,11)
     >>> b = mpq(1,2)
     >>> c = F(5,7)
+    >>> class Z:
+    ...     def __mpz__(self): return mpz(2)
+    >>> class Q:
+    ...     def __mpz__(self): return mpz(1)
+    ...     def __mpq__(self): return mpq(3,2)
+    >>> z = Z()
+    >>> q = Q()
 
 Test elementary operations
 ==========================
@@ -113,6 +120,14 @@ Test division
     mpz(1)
     >>> mpq(355, 113) // mpz(2)
     mpz(1)
+    >>> a / z
+    mpq(3,22)
+    >>> mpq(355, 113) // z
+    mpz(1)
+    >>> mpq(3,11) / q
+    mpq(2,11)
+    >>> mpq(3,11) // q
+    mpz(0)
 
 Test modulo
 -----------
@@ -121,6 +136,10 @@ Test modulo
     mpq(3,11)
     >>> b%a
     mpq(5,22)
+    >>> a%z
+    mpq(3,11)
+    >>> mpq(3,1) % q
+    mpq(0,1)
     >>> divmod(a,b)
     (mpz(0), mpq(3,11))
     >>> divmod(b,a)

--- a/test/test_mpz.txt
+++ b/test/test_mpz.txt
@@ -22,6 +22,9 @@ Testing of mpz functionality is split into multiple files.
     >>> a = mpz(123)
     >>> b = mpz(456)
     >>> c = 12345678901234567890
+    >>> class Z:
+    ...     def __mpz__(self): return mpz(2)
+    >>> z = Z()
 
 Test elementary operations
 ==========================
@@ -136,6 +139,10 @@ Test division
     100371373180768844
     >>> a**10//c
     mpz(64)
+    >>> a / z
+    mpfr('61.5')
+    >>> a // z
+    mpz(61)
 
 Test modulo
 -----------
@@ -144,6 +151,8 @@ Test modulo
     mpz(123)
     >>> b%a
     mpz(87)
+    >>> a%z
+    mpz(1)
     >>> divmod(a,b)
     (mpz(0), mpz(123))
     >>> divmod(b,a)


### PR DESCRIPTION
Fix issue #214
Allow arithmetic operations between gmpy2 numbers and objects with custom __mpz__, __mpq__, __mpfr__ or __mpc__ methods.
Add tests and documentation (conversion.rst).

This branch pass travis-ci test if merged with PR #216. (see https://travis-ci.org/vinklein/gmpy/builds/502597870)