### PR TITLE
Fix issue #226 gmpy2's round2 segfault

### DIFF
--- a/src/gmpy2_math.c
+++ b/src/gmpy2_math.c
@@ -1440,9 +1440,10 @@ static PyObject *
 GMPy_Real_Round2(PyObject *x, PyObject *y, CTXT_Object *context)
 {
     MPFR_Object *result, *tempx;
-    long n = 0;
+    long n;
 
     CHECK_CONTEXT(context);
+    n = GET_MPFR_PREC(context);
 
     if (y) {
         n = PyIntOrLong_AsLong(y);

--- a/test/test_gmpy2_math.txt
+++ b/test/test_gmpy2_math.txt
@@ -99,6 +99,16 @@ Tests round2
 mpfr('1.5',2)
 >>> gmpy2.round2(r, 5)
 mpfr('1.69',5)
+>>> gmpy2.round2(r)
+mpfr('1.6565656499999999')
+>>> gmpy2.round2(mpq('1/3'))
+mpfr('0.33333333333333331')
+>>> gmpy2.round2(mpq('1/3'), 30)
+mpfr('0.33333333349',30)
+>>> gmpy2.round2(r, -5)
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+ValueError: invalid precision
 >>> gmpy2.round2(mpc(4, 4), 5)
 Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
@@ -106,6 +116,10 @@ TypeError: round2() argument type not supported
 >>> gmpy2.round2(mpz(5), 5)
 mpfr('5.0',5)
 >>> gmpy2.round2(5, 6, 5)
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+TypeError: round2() requires 1 or 2 arguments
+>>> gmpy2.round2()
 Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
 TypeError: round2() requires 1 or 2 arguments


### PR DESCRIPTION
Fix gmpy2's round2 segfault when this function is called with one parameter.

- Use context default precision for mpfr instead of 0.
- Add few tests for round2.