### PR TITLE
Fix root_of_unity warning and doctests errors. When mpc version != 1.0.0

### DIFF
--- a/src/gmpy2_mpc_misc.h
+++ b/src/gmpy2_mpc_misc.h
@@ -36,8 +36,10 @@ extern "C" {
 static PyObject * GMPy_Complex_Phase(PyObject *x, CTXT_Object *context);
 static PyObject * GMPy_Context_Phase(PyObject *self, PyObject *other);
 
+#ifdef MPC_110
 static PyObject * GMPy_Complex_Root_Of_Unity(PyObject *n, PyObject *k, CTXT_Object *context);
 static PyObject * GMPy_Context_Root_Of_Unity(PyObject *self, PyObject *args);
+#endif
 
 static PyObject * GMPy_Complex_Norm(PyObject *x, CTXT_Object *context);
 static PyObject * GMPy_Context_Norm(PyObject *self, PyObject *other);

--- a/test/test_mpc.txt
+++ b/test/test_mpc.txt
@@ -265,25 +265,25 @@ mpfr('0.89605538457134393')
 
 Test root_of_unity
 ------------------
->>> gmpy2.root_of_unity(1,1)
+>>> gmpy2.root_of_unity(1,1) # doctest: +SKIP_NO_ROOT_OF_UNITY
 mpc('1.0+0.0j')
->>> gmpy2.root_of_unity(1,2)
+>>> gmpy2.root_of_unity(1,2) # doctest: +SKIP_NO_ROOT_OF_UNITY
 mpc('1.0+0.0j')
->>> gmpy2.root_of_unity(2,1)
+>>> gmpy2.root_of_unity(2,1) # doctest: +SKIP_NO_ROOT_OF_UNITY
 mpc('-1.0+0.0j')
->>> gmpy2.root_of_unity(3,1)
+>>> gmpy2.root_of_unity(3,1) # doctest: +SKIP_NO_ROOT_OF_UNITY
 mpc('-0.5+0.8660254037844386j')
->>> gmpy2.root_of_unity(3,2)
+>>> gmpy2.root_of_unity(3,2) # doctest: +SKIP_NO_ROOT_OF_UNITY
 mpc('-0.5-0.8660254037844386j')
->>> gmpy2.root_of_unity(3,3)
+>>> gmpy2.root_of_unity(3,3) # doctest: +SKIP_NO_ROOT_OF_UNITY
 mpc('1.0+0.0j')
->>> gmpy2.ieee(128).root_of_unity(3,1)
+>>> gmpy2.ieee(128).root_of_unity(3,1) # doctest: +SKIP_NO_ROOT_OF_UNITY
 mpc('-0.5+0.866025403784438646763723170752936161j',(113,113))
->>> gmpy2.ieee(128).root_of_unity()
+>>> gmpy2.ieee(128).root_of_unity() # doctest: +SKIP_NO_ROOT_OF_UNITY
 Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
 TypeError: root_of_unity() requires 2 arguments
->>> gmpy2.ieee(128).root_of_unity('a','b')
+>>> gmpy2.ieee(128).root_of_unity('a','b') # doctest: +SKIP_NO_ROOT_OF_UNITY
 Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
 TypeError: root_of_unity() requires integer arguments


### PR DESCRIPTION
Currently if gmpy2 is used with a mpc version older than 1.1.0 it generate a compilation warning and doctests failures as `gmpy2.root_of_unity` attribute is not defined.

```
Example of doctests failures :
Failed example:
    gmpy2.root_of_unity(1,2)
Exception raised:
    Traceback (most recent call last):
      File "/opt/python/3.5.6/lib/python3.5/doctest.py", line 1321, in __run
        compileflags, 1), test.globs)
      File "<doctest test_mpc.txt[114]>", line 1, in <module>
        gmpy2.root_of_unity(1,2)
    AttributeError: module 'gmpy2' has no attribute 'root_of_unity'
```
see: https://travis-ci.org/vinklein/gmpy/builds/509298994

- Fix `gmpy2_mpc_misc.h` to avoid generating warning
- Create a doctest flag and a doctest parser to SKIP doctests if `root_of_unity` is not defined
- Flag the appropriate doctests