### PR TITLE
Issue #238: Fix unreconized mpc_cmp_abs symbol

### DIFF
--- a/src/gmpy2_cmp.c
+++ b/src/gmpy2_cmp.c
@@ -473,6 +473,10 @@ GMPy_MPANY_cmp_abs(PyObject *self, PyObject *args)
         return result;
     }
 
+#ifndef MPC_110
+    TYPE_ERROR("cmp_abs() requires integer, rational, or real arguments");
+    return NULL;
+#else
     if (IS_COMPLEX(arg0) && IS_COMPLEX(arg1)) {
             MPC_Object *tempx = NULL;
             MPC_Object *tempy = NULL;
@@ -496,5 +500,6 @@ GMPy_MPANY_cmp_abs(PyObject *self, PyObject *args)
 
     TYPE_ERROR("cmp_abs() requires integer, rational, real, or complex arguments");
     return NULL;
+#endif
 }
 

--- a/test/runtests.py
+++ b/test/runtests.py
@@ -43,10 +43,11 @@ if debug:
 else:
     repeat = 1
 
-# If mpc version < 1.1.0 gmpy2.root_of_unity may not be defined.
-# We create a doctest flag to skip a doctest if root_of_unity is not defined
-SKIP_NO_ROOT_OF_UNITY = doctest.register_optionflag("SKIP_NO_ROOT_OF_UNITY")
-has_root_of_unity = 'root_of_unity' in dir(gmpy2)
+# If mpc version < 1.1.0 gmpy2.root_of_unity is defined and gmpy2.cmp_abs
+# doesn't manage complex parameters.
+# We create a doctest flag to skip a doctest when mpc version is < 1.1.0
+SKIP_MPC_LESS_THAN_110 = doctest.register_optionflag("SKIP_MPC_LESS_THAN_110")
+mpc_version_110 = 'root_of_unity' in dir(gmpy2) # True if mpc version >= 1.1.0
 
 SKIP_IN_DEBUG_MODE = doctest.register_optionflag("SKIP_IN_DEBUG_MODE")
 
@@ -56,7 +57,7 @@ class Gmpy2DocTestParser(DocTestParser):
         for example in examples:
             if not isinstance(example, Example):
                 continue
-            if not has_root_of_unity and SKIP_NO_ROOT_OF_UNITY in example.options:
+            if not mpc_version_110 and SKIP_MPC_LESS_THAN_110 in example.options:
                 example.options[SKIP] = True
             if debug and SKIP_IN_DEBUG_MODE in example.options:
                 example.options[SKIP] = True

--- a/test/test_gmpy2_cmp.txt
+++ b/test/test_gmpy2_cmp.txt
@@ -63,20 +63,20 @@ MPC Test comparisons
 Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
 TypeError: ** message detail varies **
->>> cmp_abs(mpc(1,2), mpc(3,4))
+>>> cmp_abs(mpc(1,2), mpc(3,4)) # doctest: +SKIP_MPC_LESS_THAN_110
 -1
->>> cmp_abs(mpc(1,2), mpc(1,2))
+>>> cmp_abs(mpc(1,2), mpc(1,2)) # doctest: +SKIP_MPC_LESS_THAN_110
 0
->>> cmp_abs(mpc(3,4), mpc(1,2))
+>>> cmp_abs(mpc(3,4), mpc(1,2)) # doctest: +SKIP_MPC_LESS_THAN_110
 1
 >>> gmpy2.get_context().clear_flags()
 >>> nan()
 mpfr('nan')
 >>> gmpy2.get_context().erange
 False
->>> cmp_abs(mpc(nan(),1), mpc(4.5))
+>>> cmp_abs(mpc(nan(),1), mpc(4.5)) # doctest: +SKIP_MPC_LESS_THAN_110
 0
->>> gmpy2.get_context().erange
+>>> gmpy2.get_context().erange # doctest: +SKIP_MPC_LESS_THAN_110
 True
 
 

--- a/test/test_mpc.txt
+++ b/test/test_mpc.txt
@@ -256,25 +256,25 @@ mpfr('0.89605538457134393')
 
 Test root_of_unity
 ------------------
->>> gmpy2.root_of_unity(1,1) # doctest: +SKIP_NO_ROOT_OF_UNITY
+>>> gmpy2.root_of_unity(1,1) # doctest: +SKIP_MPC_LESS_THAN_110
 mpc('1.0+0.0j')
->>> gmpy2.root_of_unity(1,2) # doctest: +SKIP_NO_ROOT_OF_UNITY
+>>> gmpy2.root_of_unity(1,2) # doctest: +SKIP_MPC_LESS_THAN_110
 mpc('1.0+0.0j')
->>> gmpy2.root_of_unity(2,1) # doctest: +SKIP_NO_ROOT_OF_UNITY
+>>> gmpy2.root_of_unity(2,1) # doctest: +SKIP_MPC_LESS_THAN_110
 mpc('-1.0+0.0j')
->>> gmpy2.root_of_unity(3,1) # doctest: +SKIP_NO_ROOT_OF_UNITY
+>>> gmpy2.root_of_unity(3,1) # doctest: +SKIP_MPC_LESS_THAN_110
 mpc('-0.5+0.8660254037844386j')
->>> gmpy2.root_of_unity(3,2) # doctest: +SKIP_NO_ROOT_OF_UNITY
+>>> gmpy2.root_of_unity(3,2) # doctest: +SKIP_MPC_LESS_THAN_110
 mpc('-0.5-0.8660254037844386j')
->>> gmpy2.root_of_unity(3,3) # doctest: +SKIP_NO_ROOT_OF_UNITY
+>>> gmpy2.root_of_unity(3,3) # doctest: +SKIP_MPC_LESS_THAN_110
 mpc('1.0+0.0j')
->>> gmpy2.ieee(128).root_of_unity(3,1) # doctest: +SKIP_NO_ROOT_OF_UNITY
+>>> gmpy2.ieee(128).root_of_unity(3,1) # doctest: +SKIP_MPC_LESS_THAN_110
 mpc('-0.5+0.866025403784438646763723170752936161j',(113,113))
->>> gmpy2.ieee(128).root_of_unity() # doctest: +SKIP_NO_ROOT_OF_UNITY
+>>> gmpy2.ieee(128).root_of_unity() # doctest: +SKIP_MPC_LESS_THAN_110
 Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
 TypeError: root_of_unity() requires 2 arguments
->>> gmpy2.ieee(128).root_of_unity('a','b') # doctest: +SKIP_NO_ROOT_OF_UNITY
+>>> gmpy2.ieee(128).root_of_unity('a','b') # doctest: +SKIP_MPC_LESS_THAN_110
 Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
 TypeError: root_of_unity() requires integer arguments


### PR DESCRIPTION
Fix issue #238:
- Avoid to call `mpc_cmp_abs` function when mpc version is lesser than 1.1.0.
- Adapt doctest accordingly.