### PR TITLE
Fix issue #237 allow to use a pair of objects defining __mpz__  to initialize an mpq.

### DIFF
--- a/src/gmpy2_cache.c
+++ b/src/gmpy2_cache.c
@@ -483,8 +483,8 @@ GMPy_MPQ_NewInit(PyTypeObject *type, PyObject *args, PyObject *keywds)
         m = PyTuple_GetItem(args, 1);
 
         if (IS_RATIONAL(n) && IS_RATIONAL(m)) {
-           result = GMPy_MPQ_From_Rational(n, context);
-           temp = GMPy_MPQ_From_Rational(m, context);
+           result = GMPy_MPQ_From_Number(n, context);
+           temp = GMPy_MPQ_From_Number(m, context);
            if (!result || !temp) {
                Py_XDECREF((PyObject*)result);
                Py_XDECREF((PyObject*)temp);

--- a/test/test_gmpy2_constructors.txt
+++ b/test/test_gmpy2_constructors.txt
@@ -31,6 +31,13 @@ Test mpq conversion
 True
 >>> 2*x == 3
 True
+>>> mpq(z, z)
+mpq(1,1)
+>>> class Three:
+...     def __mpz__(self): return mpz(3)
+...
+>>> mpq(z, Three())
+mpq(2,3)
 >>> mpq(b)
 Traceback (most recent call last):
 ...


### PR DESCRIPTION
- In mpq init replace `GMPy_MPQ_From_Rational` call by `GMPy_MPQ_From_Number`.
- Add few doctests.

The ubuntu travis-ci doctests failures are fixed by PR #239