### PR TITLE
Fix issue #251

### DIFF
--- a/src/gmpy2_cmp.c
+++ b/src/gmpy2_cmp.c
@@ -84,7 +84,7 @@ GMPy_MPANY_cmp(PyObject *self, PyObject *args)
         MPQ_Object *tempx = NULL;
         MPZ_Object *tempy = NULL;
 
-        if (!(tempx = GMPy_MPQ_From_Rational(arg0, context)) ||
+        if (!(tempx = GMPy_MPQ_From_Number(arg0, context)) ||
             !(tempy = GMPy_MPZ_From_Integer(arg1, context))) {
             /* LCOV_EXCL_START */
             Py_XDECREF((PyObject*)tempx);
@@ -104,7 +104,7 @@ GMPy_MPANY_cmp(PyObject *self, PyObject *args)
         MPQ_Object *tempy = NULL;
 
         if (!(tempx = GMPy_MPZ_From_Integer(arg0, context)) ||
-            !(tempy = GMPy_MPQ_From_Rational(arg1, context))) {
+            !(tempy = GMPy_MPQ_From_Number(arg1, context))) {
             /* LCOV_EXCL_START */
             Py_XDECREF((PyObject*)tempx);
             Py_XDECREF((PyObject*)tempy);
@@ -121,8 +121,8 @@ GMPy_MPANY_cmp(PyObject *self, PyObject *args)
     if (IS_RATIONAL(arg0) && IS_RATIONAL(arg1)) {
         MPQ_Object *tempx = NULL, *tempy = NULL;
 
-        if (!(tempx = GMPy_MPQ_From_Rational(arg0, context)) ||
-            !(tempy = GMPy_MPQ_From_Rational(arg1, context))) {
+        if (!(tempx = GMPy_MPQ_From_Number(arg0, context)) ||
+            !(tempy = GMPy_MPQ_From_Number(arg1, context))) {
             /* LCOV_EXCL_START */
             Py_XDECREF((PyObject*)tempx);
             Py_XDECREF((PyObject*)tempy);
@@ -165,7 +165,7 @@ GMPy_MPANY_cmp(PyObject *self, PyObject *args)
             MPQ_Object *tempy = NULL;
 
         if (!(tempx = GMPy_MPFR_From_Real(arg0, 1, context)) ||
-            !(tempy = GMPy_MPQ_From_Rational(arg1, context))) {
+            !(tempy = GMPy_MPQ_From_Number(arg1, context))) {
             /* LCOV_EXCL_START */
             Py_XDECREF((PyObject*)tempx);
             Py_XDECREF((PyObject*)tempy);
@@ -227,7 +227,7 @@ GMPy_MPANY_cmp(PyObject *self, PyObject *args)
             MPQ_Object *tempx = NULL;
             MPFR_Object *tempy = NULL;
 
-        if (!(tempx = GMPy_MPQ_From_Rational(arg0, context)) ||
+        if (!(tempx = GMPy_MPQ_From_Number(arg0, context)) ||
             !(tempy = GMPy_MPFR_From_Real(arg1, 1, context))) {
             /* LCOV_EXCL_START */
             Py_XDECREF((PyObject*)tempx);

--- a/src/gmpy2_richcompare.c
+++ b/src/gmpy2_richcompare.c
@@ -81,8 +81,8 @@ GMPy_RichCompare_Slot(PyObject *a, PyObject *b, int op)
         }
 
         if (IS_RATIONAL(b)) {
-            tempa = (PyObject*)GMPy_MPQ_From_Rational(a, context);
-            tempb = (PyObject*)GMPy_MPQ_From_Rational(b, context);
+            tempa = (PyObject*)GMPy_MPQ_From_Number(a, context);
+            tempb = (PyObject*)GMPy_MPQ_From_Number(b, context);
             if (!tempa || !tempb) {
                 Py_XDECREF(a);
                 Py_XDECREF(b);
@@ -119,7 +119,7 @@ GMPy_RichCompare_Slot(PyObject *a, PyObject *b, int op)
         }
 
         if (IS_RATIONAL(b)) {
-            if (!(tempb = (PyObject*)GMPy_MPQ_From_Rational(b, context))) {
+            if (!(tempb = (PyObject*)GMPy_MPQ_From_Number(b, context))) {
                 return NULL;
             }
             c = mpq_cmp(MPQ(a), MPQ(tempb));
@@ -216,7 +216,7 @@ GMPy_RichCompare_Slot(PyObject *a, PyObject *b, int op)
         }
 
         if (IS_RATIONAL(b)) {
-            if (!(tempb = (PyObject*)GMPy_MPQ_From_Rational(b, context))) {
+            if (!(tempb = (PyObject*)GMPy_MPQ_From_Number(b, context))) {
                 return NULL;
             }
             mpfr_clear_flags();

--- a/test/test_gmpy2_cmp.txt
+++ b/test/test_gmpy2_cmp.txt
@@ -79,7 +79,35 @@ False
 >>> gmpy2.get_context().erange # doctest: +SKIP_MPC_LESS_THAN_110
 True
 
+Tests custom objects comparisons
+--------------------------------
 
-
-
-
+>>> class Z:
+...     def __mpz__(self): return mpz(1)
+>>> class Q:
+...     def __mpz__(self): return mpz(1)
+...     def __mpq__(self): return mpq(3,2)
+>>> class R:
+...     def __mpfr__(self): return mpfr(1.5)
+>>> class Cx:
+...     def __mpc__(self): return mpc(42,67)
+>>> z = Z()
+>>> q = Q()
+>>> r = R()
+>>> cx = Cx()
+>>> cmp(mpz(1), z)
+0
+>>> cmp(z, mpz(2))
+-1
+>>> cmp(mpz(1), q)
+-1
+>>> cmp(mpz(1), mpz(q))
+0
+>>> cmp(mpq(3,2), q)
+0
+>>> cmp(q, mpq(3,5))
+1
+>>> cmp(mpfr(1.5), q)
+0
+>>> cmp(r, mpfr(1.5))
+0

--- a/test/test_gmpy2_comp.txt
+++ b/test/test_gmpy2_comp.txt
@@ -154,3 +154,40 @@ Traceback (most recent call last):
 TypeError: no ordering relation is defined for complex numbers
 >>> 1
 1
+
+Tests custom objects comparisons
+--------------------------------
+
+>>> class Z:
+...     def __mpz__(self): return mpz(1)
+>>> class Q:
+...     def __mpz__(self): return mpz(1)
+...     def __mpq__(self): return mpq(3,2)
+>>> class R:
+...     def __mpfr__(self): return mpfr(1.5)
+>>> class Cx:
+...     def __mpc__(self): return mpc(42,67)
+>>> z = Z()
+>>> q = Q()
+>>> r = R()
+>>> cx = Cx()
+>>> mpz(1) == z
+True
+>>> z == mpz(2)
+False
+>>> mpz(1) == q
+False
+>>> mpz(1) == mpz(q)
+True
+>>> mpq(3,2) == q
+True
+>>> q == mpq(3,5)
+False
+>>> mpfr(1.5) == q
+True
+>>> r == mpfr(1.5)
+True
+>>> r == a
+False
+>>> c == cx
+False


### PR DESCRIPTION
Fix richcompare and gmpy2_cmp for comparison between gmpy2 numbers and custom rational objects

- Replace GMPy_MPQ_From_Rational calls with GMPy_MPQ_From_Number
- Add tests for these cases.