### PR TITLE
Convert C file character encodings to UTF-8.

### DIFF
--- a/src/gmpy2.c
+++ b/src/gmpy2.c
@@ -43,7 +43,7 @@
 
 /*
  * originally written for GMP-2.0 (by AMK...?)
- * Rewritten by Niels Möller, May 1996
+ * Rewritten by Niels MÃ¶ller, May 1996
  *
  * Version for GMP-4, Python 2.X, with support for MSVC++6,
  * addition of mpf's, &c: Alex Martelli (now aleaxit@gmail.com, Nov 2000).

--- a/src/mpz_pylong.c
+++ b/src/mpz_pylong.c
@@ -1,6 +1,6 @@
 /* mpz <-> pylong conversion and "pythonhash" for mpz
  *
- * Originally written for sage (http://sagemath.org) by Gonzalo Tornari≠a
+ * Originally written for sage (http://sagemath.org) by Gonzalo Tornar√≠a
  * <tornaria@math.utexas.edu>. If you improve on these functions, please
  * contribute them back to sage by posting to sage-devel@googlegroups.com
  * or by sending an email to the original author.


### PR DESCRIPTION
Currently, src/gmpy2.c is ISO8859-1.  I don't recognize the encoding of mpz_pylong.c.  It might be doubly encoded.  In any case, this commit changes them both to Unicode.