### PR TITLE
Add access to gmp limbs API

### DIFF
--- a/src/gmpy2.c
+++ b/src/gmpy2.c
@@ -594,6 +594,7 @@ static PyObject *GMPyExc_Erange = NULL;
 #include "gmpy2_mpq_misc.c"
 #include "gmpy2_mpz_misc.c"
 #include "gmpy2_xmpz_misc.c"
+#include "gmpy2_xmpz_limbs.c"
 
 #ifdef VECTOR
 #include "gmpy2_vector.c"
@@ -1118,6 +1119,11 @@ PyMODINIT_FUNC initgmpy2(void)
 
     Py_INCREF(&XMPZ_Type);
     PyModule_AddObject(gmpy_module, "xmpz", (PyObject*)&XMPZ_Type);
+
+    PyObject* xmpz = XMPZ_Type.tp_dict;
+    PyObject* limb_size = PyIntOrLong_FromSize_t(sizeof(mp_limb_t));
+    PyDict_SetItemString(xmpz, "limb_size", limb_size);
+    Py_DECREF(limb_size);
 
     /* Add the MPQ type to the module namespace. */
 

--- a/src/gmpy2.h
+++ b/src/gmpy2.h
@@ -497,6 +497,7 @@ typedef struct {
 
 #include "gmpy2_xmpz_inplace.h"
 #include "gmpy2_xmpz_misc.h"
+#include "gmpy2_xmpz_limbs.h"
 
 /* Support for mpq specific functions. */
 

--- a/src/gmpy2_xmpz.c
+++ b/src/gmpy2_xmpz.c
@@ -166,6 +166,11 @@ static PyMethodDef GMPy_XMPZ_methods [] =
     { "iter_set", (PyCFunction)GMPy_XMPZ_Method_IterSet, METH_VARARGS | METH_KEYWORDS, GMPy_doc_xmpz_method_iter_set },
     { "make_mpz", GMPy_XMPZ_Method_MakeMPZ, METH_NOARGS, GMPy_doc_xmpz_method_make_mpz },
     { "num_digits", GMPy_MPZ_Method_NumDigits, METH_VARARGS, GMPy_doc_mpz_method_num_digits },
+    { "num_limbs", GMPy_XMPZ_Method_NumLimbs, METH_NOARGS, GMPy_doc_xmpz_method_num_limbs },
+    { "limbs_read", GMPy_XMPZ_Method_LimbsRead, METH_NOARGS, GMPy_doc_xmpz_method_limbs_read },
+    { "limbs_write", GMPy_XMPZ_Method_LimbsWrite, METH_O, GMPy_doc_xmpz_method_limbs_write },
+    { "limbs_modify", GMPy_XMPZ_Method_LimbsModify, METH_O, GMPy_doc_xmpz_method_limbs_modify },
+    { "limbs_finish", GMPy_XMPZ_Method_LimbsFinish, METH_O, GMPy_doc_xmpz_method_limbs_finish },
     { NULL, NULL, 1 }
 };
 

--- a/src/gmpy2_xmpz_limbs.c
+++ b/src/gmpy2_xmpz_limbs.c
@@ -1,0 +1,69 @@
+PyDoc_STRVAR(GMPy_doc_xmpz_method_num_limbs,
+"xmpz.num_limbs() -> int\n\n"
+"     Return the number of limbs of 'xmpz'.");
+static PyObject* GMPy_XMPZ_Method_NumLimbs(PyObject* obj, PyObject* other)
+{
+  return PyIntOrLong_FromSize_t(mpz_size(XMPZ(obj)));
+}
+
+PyDoc_STRVAR(GMPy_doc_xmpz_method_limbs_read,
+"xmpz.limbs_read() -> int\n\n"
+"     Returns the address of the immutable buffer representing the \n"
+"     limbs of 'xmpz'.");
+static PyObject* GMPy_XMPZ_Method_LimbsRead(PyObject* obj, PyObject* args)
+{
+  const mp_limb_t* limbs = mpz_limbs_read(XMPZ(obj));
+  return PyLong_FromVoidPtr((void *) limbs);
+}
+
+PyDoc_STRVAR(GMPy_doc_xmpz_method_limbs_write,
+"xmpz.limbs_write(n) -> int\n\n"
+"     Returns the address of a mutable buffer representing the limbs \n"
+"     of 'xmpz', resized so that it may hold at least 'n' limbs.\n"
+"     Must be followed by a call to 'xmpz.limbs_finish(n)' after writing to\n"
+"     the returned address in order for the changes to take effect.\n"
+"     WARNING: this operation is destructive and may destroy the old \n"
+"              value of 'xmpz'");
+static PyObject* GMPy_XMPZ_Method_LimbsWrite(PyObject* obj, PyObject* other)
+{
+    if (!PyIntOrLong_Check(other)) {
+      TYPE_ERROR("number of limbs must be an int or a long");
+      return NULL;
+    }
+    size_t num_limbs = (size_t) PyIntOrLong_AsSsize_t(other);
+    mp_limb_t * limbs = mpz_limbs_write(XMPZ(obj), (mp_size_t) num_limbs);
+    return PyLong_FromVoidPtr((void *) limbs);
+}
+
+PyDoc_STRVAR(GMPy_doc_xmpz_method_limbs_modify,
+"xmpz.limbs_modify(n) -> int\n\n"
+"     Returns the address of a mutable buffer representing the limbs \n"
+"     of 'xmpz', resized so that it may hold at least 'n' limbs.\n"
+"     Must be followed by a call to 'xmpz.limbs_finish(n)' after writing to\n"
+"     the returned address in order for the changes to take effect.");
+static PyObject* GMPy_XMPZ_Method_LimbsModify(PyObject* obj, PyObject* other)
+{
+    if (!PyIntOrLong_Check(other)) {
+      TYPE_ERROR("number of limbs must be an int or a long");
+      return NULL;
+    }
+    size_t num_limbs = (size_t) PyIntOrLong_AsSsize_t(other);
+    mp_limb_t * limbs = mpz_limbs_modify(XMPZ(obj), (mp_size_t) num_limbs);
+    return PyLong_FromVoidPtr((void *) limbs);
+}
+
+PyDoc_STRVAR(GMPy_doc_xmpz_method_limbs_finish,
+"xmpz.limbs_finish(n)\n\n"
+"     Must be called after writing to the address returned by \n"
+"     'xmpz.limbs_write(n)' or 'xmpz.limbs_modify(n)' to update\n"
+"     the limbs of 'xpmz'.");
+static PyObject* GMPy_XMPZ_Method_LimbsFinish(PyObject* obj, PyObject* other)
+{
+  if (!PyIntOrLong_Check(other)) {
+    TYPE_ERROR("number of limbs must be an int or long");
+    return NULL;
+  }
+  size_t num_limbs = (size_t) PyIntOrLong_AsSsize_t(other);
+  mpz_limbs_finish(XMPZ(obj), num_limbs);
+  Py_RETURN_NONE;
+}

--- a/src/gmpy2_xmpz_limbs.h
+++ b/src/gmpy2_xmpz_limbs.h
@@ -1,0 +1,41 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * gmpy2_xmpz_limbs.c                                                      *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Python interface to the GMP or MPIR, MPFR, and MPC multiple precision   *
+ * libraries.                                                              *
+ *                                                                         *
+ * Copyright 2020 Tyler Lanphear                                           *
+ *                                                                         *
+ * This file is part of GMPY2.                                             *
+ *                                                                         *
+ * GMPY2 is free software: you can redistribute it and/or modify it under  *
+ * the terms of the GNU Lesser General Public License as published by the  *
+ * Free Software Foundation, either version 3 of the License, or (at your  *
+ * option) any later version.                                              *
+ *                                                                         *
+ * GMPY2 is distributed in the hope that it will be useful, but WITHOUT    *
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or   *
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public    *
+ * License for more details.                                               *
+ *                                                                         *
+ * You should have received a copy of the GNU Lesser General Public        *
+ * License along with GMPY2; if not, see <http://www.gnu.org/licenses/>    *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef GMPY_XMPZ_LIMBS_H
+#define GMPY_XMPZ_LIMBS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static PyObject* GMPy_XMPZ_Method_NumLimbs(PyObject* obj, PyObject* other);
+static PyObject* GMPy_XMPZ_Method_LimbsRead(PyObject* obj, PyObject* other);
+static PyObject* GMPy_XMPZ_Method_LimbsWrite(PyObject* obj, PyObject* other);
+static PyObject* GMPy_XMPZ_Method_LimbsModify(PyObject* obj, PyObject* other);
+static PyObject* GMPy_XMPZ_Method_LimbsFinish(PyObject* obj, PyObject* other);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/test/test_gmpy2_xmpz_limbs.txt
+++ b/test/test_gmpy2_xmpz_limbs.txt
@@ -1,0 +1,42 @@
+Testing of gmpy2 mpz limbs
+--------------------------
+
+    >>> import gmpy2, ctypes
+    >>> from gmpy2 import xmpz
+    >>> from ctypes import memmove
+
+Test limbs_read/limbs_write/limbs_finish
+----------------------------------------
+
+    >>> x=xmpz(123456789L);y=xmpz(0);
+    >>> x_limbs, num_limbs=x.limbs_read(),x.num_limbs();
+    >>> x_limbs != 0
+    True
+    >>> num_limbs > 0
+    True
+    >>> y_limbs=y.limbs_write(num_limbs);
+    >>> y_limbs != 0
+    True
+    >>> memmove(y_limbs, x_limbs, num_limbs * xmpz.limb_size) > 0
+    True
+    >>> y.limbs_finish(num_limbs)
+    >>> long(y)
+    123456789L
+
+Test limbs_read/limbs_modify/limbs_finish
+-----------------------------------------
+
+    >>> x=xmpz(987654321L);y=xmpz(0);
+    >>> x_limbs, num_limbs=x.limbs_read(),x.num_limbs();
+    >>> x_limbs != 0
+    True
+    >>> num_limbs > 0
+    True
+    >>> y_limbs=y.limbs_modify(num_limbs);
+    >>> y_limbs != 0
+    True
+    >>> memmove(y_limbs, x_limbs, num_limbs * xmpz.limb_size) > 0
+    True
+    >>> y.limbs_finish(num_limbs)
+    >>> long(y)
+    987654321L


### PR DESCRIPTION
This PR exposes the `mpz_limbs` [interface](https://gmplib.org/manual/Integer-Special-Functions.html) through 5 new methods on `xmpz` to provide access to the backing storage of an `xmpz` object. This is for fast access to the `gmp` internals to perform quick compression/decompression of the underlying `mpz` data.

Methods added:
- `xmpz.num_limbs() -> int`
  returns the number of `gmp` limbs underlying this `xmpz` object
- `xmpz.limbs_read() -> int`
  returns the address of an immutable buffer representing the limbs of `xmpz`
- `xmpz.limbs_write(n) -> int`
  potentially reallocates and returns the address of a mutable buffer representing the limbs of `xmpz`, sized to hold at least `n` limbs. May overwrite the existing limbs of `xmpz`.
- `xmpz.limbs_modify(n) -> int`
  potentially reallocates and returns the address of a mutable buffer representing the limbs of `xmpz`, sized to hold at least `n` limbs.
- `xmpz.limbs_finish(n) -> int`
  must be called after writing to the address returned by `xmpz.limbs(n)` to update the limbs of `xmpz` (and thereby see the changes take effect)

Attributes added:
- `xmpz.limb_size`
  Size of a `gmp` limb in bytes. Equal to `sizeof(mp_limb_t)`.