### PR TITLE
Correctly read rounding mode strings when characters are multibyte

### DIFF
--- a/src/gmpy2.h
+++ b/src/gmpy2.h
@@ -336,7 +336,8 @@ typedef struct {
 #define Py2or3String_FromFormat     PyUnicode_FromFormat
 #define Py2or3String_Check          PyUnicode_Check
 #define Py2or3String_Format         PyUnicode_Format
-#define Py2or3String_AsString       PyUnicode_AS_DATA
+#define Py2or3String_Type           Py_UCS4
+#define Py2or3String_1Char(obj)     (PyUnicode_READY(obj) ? (Py_UCS4)0 : PyUnicode_READ_CHAR(obj, 0))
 #define PyStrOrUnicode_Check(op)    (PyBytes_Check(op) || PyUnicode_Check(op))
 #define PyIntOrLong_FromLong        PyLong_FromLong
 #define PyIntOrLong_Check(op)       PyLong_Check(op)
@@ -350,7 +351,8 @@ typedef struct {
 #define Py2or3String_FromFormat     PyString_FromFormat
 #define Py2or3String_Check          PyString_Check
 #define Py2or3String_Format         PyString_Format
-#define Py2or3String_AsString       PyString_AsString
+#define Py2or3String_Type           char
+#define Py2or3String_1Char(obj)     PyString_AsString(obj)[0]
 #define PyStrOrUnicode_Check(op)    (PyString_Check(op) || PyUnicode_Check(op))
 #define PyIntOrLong_FromLong        PyInt_FromLong
 #define PyIntOrLong_Check(op)       (PyInt_Check(op) || PyLong_Check(op))

--- a/src/gmpy2_mpmath.c
+++ b/src/gmpy2_mpmath.c
@@ -73,7 +73,7 @@ Pympz_mpmath_normalize(PyObject *self, PyObject *args)
     long carry = 0;
     PyObject *exp = 0, *newexp = 0, *newexp2 = 0, *tmp = 0, *rndstr = 0;
     MPZ_Object *man = 0, *upper = 0, *lower = 0;
-    char rnd = 0;
+    Py2or3String_Type rnd = 0;
     int err1, err2, err3;
 
     if (PyTuple_GET_SIZE(args) == 6) {
@@ -105,7 +105,7 @@ Pympz_mpmath_normalize(PyObject *self, PyObject *args)
 
     /* If rndstr really is a string, extract the first character. */
     if (Py2or3String_Check(rndstr)) {
-        rnd = Py2or3String_AsString(rndstr)[0];
+        rnd = Py2or3String_1Char(rndstr);
     }
     else {
         VALUE_ERROR("invalid rounding mode specified");
@@ -134,7 +134,7 @@ Pympz_mpmath_normalize(PyObject *self, PyObject *args)
     if (bc > prec) {
         shift = bc - prec;
         switch (rnd) {
-            case 'f':
+            case (Py2or3String_Type)'f':
                 if(sign) {
                     mpz_cdiv_q_2exp(upper->z, man->z, shift);
                 }
@@ -142,7 +142,7 @@ Pympz_mpmath_normalize(PyObject *self, PyObject *args)
                     mpz_fdiv_q_2exp(upper->z, man->z, shift);
                 }
                 break;
-            case 'c':
+            case (Py2or3String_Type)'c':
                 if(sign) {
                     mpz_fdiv_q_2exp(upper->z, man->z, shift);
                 }
@@ -150,13 +150,13 @@ Pympz_mpmath_normalize(PyObject *self, PyObject *args)
                     mpz_cdiv_q_2exp(upper->z, man->z, shift);
                 }
                 break;
-            case 'd':
+            case (Py2or3String_Type)'d':
                 mpz_fdiv_q_2exp(upper->z, man->z, shift);
                 break;
-            case 'u':
+            case (Py2or3String_Type)'u':
                 mpz_cdiv_q_2exp(upper->z, man->z, shift);
                 break;
-            case 'n':
+            case (Py2or3String_Type)'n':
             default:
                 mpz_tdiv_r_2exp(lower->z, man->z, shift);
                 mpz_tdiv_q_2exp(upper->z, man->z, shift);
@@ -241,7 +241,7 @@ Pympz_mpmath_create(PyObject *self, PyObject *args)
     MPZ_Object *man = 0, *upper = 0, *lower = 0;
     int error;
 
-    const char *rnd = "f";
+    Py2or3String_Type rnd = (Py2or3String_Type)'f';
 
     if (PyTuple_GET_SIZE(args) < 2) {
         TYPE_ERROR("mpmath_create() expects 'mpz','int'[,'int','str'] arguments");
@@ -250,7 +250,7 @@ Pympz_mpmath_create(PyObject *self, PyObject *args)
 
     switch (PyTuple_GET_SIZE(args)) {
         case 4:
-            rnd = Py2or3String_AsString(PyTuple_GET_ITEM(args, 3));
+            rnd = Py2or3String_1Char(PyTuple_GET_ITEM(args, 3));
         case 3:
             prec = GMPy_Integer_AsMpBitCntAndError(PyTuple_GET_ITEM(args, 2), &error);
             if (error)
@@ -291,8 +291,8 @@ Pympz_mpmath_create(PyObject *self, PyObject *args)
 
     if (bc > prec) {
         shift = bc - prec;
-        switch (rnd[0]) {
-            case 'f':
+        switch (rnd) {
+            case (Py2or3String_Type)'f':
                 if (sign) {
                     mpz_cdiv_q_2exp(upper->z, upper->z, shift);
                 }
@@ -300,7 +300,7 @@ Pympz_mpmath_create(PyObject *self, PyObject *args)
                     mpz_fdiv_q_2exp(upper->z, upper->z, shift);
                 }
                 break;
-            case 'c':
+            case (Py2or3String_Type)'c':
                 if (sign) {
                     mpz_fdiv_q_2exp(upper->z, upper->z, shift);
                 }
@@ -308,13 +308,13 @@ Pympz_mpmath_create(PyObject *self, PyObject *args)
                     mpz_cdiv_q_2exp(upper->z, upper->z, shift);
                 }
                 break;
-            case 'd':
+            case (Py2or3String_Type)'d':
                 mpz_fdiv_q_2exp(upper->z, upper->z, shift);
                 break;
-            case 'u':
+            case (Py2or3String_Type)'u':
                 mpz_cdiv_q_2exp(upper->z, upper->z, shift);
                 break;
-            case 'n':
+            case (Py2or3String_Type)'n':
             default:
                 mpz_tdiv_r_2exp(lower->z, upper->z, shift);
                 mpz_tdiv_q_2exp(upper->z, upper->z, shift);


### PR DESCRIPTION
This is one approach that could be taken to resolve https://github.com/aleaxit/gmpy/issues/276.  It works for python 3.8 and 3.9, at least.  My reading of the docs suggests that it might work for versions as old as 3.3, but I haven't tested anything older than 3.8.