### PR TITLE
Python 3.10 compatibility.

### DIFF
--- a/src/gmpy2_convert_gmp.c
+++ b/src/gmpy2_convert_gmp.c
@@ -222,10 +222,18 @@ GMPy_PyLong_From_MPZ(MPZ_Object *obj, CTXT_Object *context)
     while ((size>0) && (result->ob_digit[size-1] == 0)) {
         size--;
     }
+#if PY_VERSION_HEX >= 0x030900A4
+    Py_SET_SIZE(result, size);
+#else
     Py_SIZE(result) = size;
+#endif
 
     if (negative) {
+#if PY_VERSION_HEX >= 0x030900A4
+        Py_SET_SIZE(result, - Py_SIZE(result));
+#else
         Py_SIZE(result) = - Py_SIZE(result);
+#endif
     }
     return (PyObject*)result;
 }

--- a/test/runtests.py
+++ b/test/runtests.py
@@ -75,7 +75,7 @@ print("  Caching Values: (Cache size)    {0}".format(gmpy2.get_cache()[0]))
 print("  Caching Values: (Size in limbs) {0}".format(gmpy2.get_cache()[1]))
 print()
 
-if sys.version.startswith('3.1'):
+if sys.version.startswith('3.1.'):
     print("Due to differences in formatting of exceptions and Python 3.x, there")
     print("will be test failures for exception handling when the tests are run")
     print("with Python 3.1. The doctest module in Python 3.2 and later does not")


### PR DESCRIPTION
The Fedora distribution has started doing experimental builds with alpha versions of python 3.10, to discover and fix problems in advance of the 3.10 release.  The gmpy code has 2 issues.  First, Py_SIZE() is no longer an lvalue in 3.10.  A Py_SET_SIZE macro was introduced in 3.9 in anticipation of this change; its use is mandatory in 3.10.  The second issue is test code that checks whether the python version string starts with "3.1"; that is true of 3.10 also, of course.  Since setup.py claims support only for 3.4 and later, it may be better to simply remove that entire block of code.  Let me know if you prefer that and I will update this commit.