### PR TITLE
Added prev_prime(x)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,3 +72,9 @@ man_pages = [
     ('index', 'gmpy2', 'gmpy2 Documentation',
      ['Case Van Horsen'], 3)
 ]
+
+import gmpy2
+if gmpy2.mp_version() >= "GMP 6.3.0":
+    tags.add('has_prev_prime')
+
+print(tags.tags)

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,11 @@ Release Notes
 
 .. currentmodule:: gmpy2
 
+Changes in gmpy2 2.2.0
+------------------------
+
+* Added prev_prime() when GMP >= 6.3
+
 Changes in gmpy2 2.1.0rc2
 -------------------------
 

--- a/docs/mpz.rst
+++ b/docs/mpz.rst
@@ -105,7 +105,19 @@ mpz Functions
 .. autofunction:: powmod_exp_list
 .. autofunction:: powmod_base_list
 .. autofunction:: powmod_sec
-.. autofunction:: prev_prime
+.. only:: has_prev_prime
+
+   ..
+       Can't use autofunction:: prev_prime as sphinx tries to import
+       regardless of has_prev_prime conditional.
+
+
+   .. function:: prev_prime(x, /) -> mpz
+
+      Return the previous *probable* prime number < x.
+
+      Only present when compiled with GMP 6.3.0 or later.
+
 .. autofunction:: primorial
 .. autofunction:: remove
 .. autofunction:: t_div

--- a/docs/mpz.rst
+++ b/docs/mpz.rst
@@ -105,6 +105,7 @@ mpz Functions
 .. autofunction:: powmod_exp_list
 .. autofunction:: powmod_base_list
 .. autofunction:: powmod_sec
+.. autofunction:: prev_prime
 .. autofunction:: primorial
 .. autofunction:: remove
 .. autofunction:: t_div

--- a/src/gmpy2.c
+++ b/src/gmpy2.c
@@ -781,7 +781,9 @@ static PyMethodDef Pygmpy_methods [] =
     { "mul", GMPy_Context_Mul, METH_VARARGS, GMPy_doc_function_mul },
     { "multi_fac", GMPy_MPZ_Function_MultiFac, METH_VARARGS, GMPy_doc_mpz_function_multi_fac },
     { "next_prime", GMPy_MPZ_Function_NextPrime, METH_O, GMPy_doc_mpz_function_next_prime },
+#if (__GNU_MP_VERSION > 6) || (__GNU_MP_VERSION == 6 &&  __GNU_MP_VERSION_MINOR >= 3)
     { "prev_prime", GMPy_MPZ_Function_PrevPrime, METH_O, GMPy_doc_mpz_function_prev_prime },
+#endif
     { "numer", GMPy_MPQ_Function_Numer, METH_O, GMPy_doc_mpq_function_numer },
     { "num_digits", GMPy_MPZ_Function_NumDigits, METH_VARARGS, GMPy_doc_mpz_function_num_digits },
     { "pack", GMPy_MPZ_pack, METH_VARARGS, doc_pack },

--- a/src/gmpy2.c
+++ b/src/gmpy2.c
@@ -406,7 +406,7 @@
  *    Adjust test suite to reflect changes in output in MPFR 4.1.0.
  *
  *    2.1.0b6
- *    Improve argument type processing by saving type information to 
+ *    Improve argument type processing by saving type information to
  *        decrease the number of type check calls. Especially helpful
  *        for mpfr and mpc types. (Not complete but common operations
  *        are done.)
@@ -474,7 +474,8 @@
  *    gcd()/lcm() now uses vectorcall protocol. (skirpichev)
  *    Expose context type. (skirpichev)
  *    Correct error in is_strong_bpsw_prp. (casevh)
- *    
+ *    Added prev_prime if part of loaded gmp
+ *
  ************************************************************************
  *
  * Discussion on sizes of C integer types.
@@ -780,6 +781,7 @@ static PyMethodDef Pygmpy_methods [] =
     { "mul", GMPy_Context_Mul, METH_VARARGS, GMPy_doc_function_mul },
     { "multi_fac", GMPy_MPZ_Function_MultiFac, METH_VARARGS, GMPy_doc_mpz_function_multi_fac },
     { "next_prime", GMPy_MPZ_Function_NextPrime, METH_O, GMPy_doc_mpz_function_next_prime },
+    { "prev_prime", GMPy_MPZ_Function_PrevPrime, METH_O, GMPy_doc_mpz_function_prev_prime },
     { "numer", GMPy_MPQ_Function_Numer, METH_O, GMPy_doc_mpq_function_numer },
     { "num_digits", GMPy_MPZ_Function_NumDigits, METH_VARARGS, GMPy_doc_mpz_function_num_digits },
     { "pack", GMPy_MPZ_pack, METH_VARARGS, doc_pack },

--- a/src/gmpy2_mpz_misc.c
+++ b/src/gmpy2_mpz_misc.c
@@ -1505,12 +1505,13 @@ GMPy_MPZ_Function_NextPrime(PyObject *self, PyObject *other)
 
 PyDoc_STRVAR(GMPy_doc_mpz_function_prev_prime,
 "prev_prime(x, /) -> mpz\n\n"
-"Return the previous *probable* prime number < x.");
+"Return the previous *probable* prime number < x.\n"
+"Only present when compiled with GMP 6.3.0 or later.");
 
+#if (__GNU_MP_VERSION > 6) || (__GNU_MP_VERSION == 6 &&  __GNU_MP_VERSION_MINOR >= 3)
 static PyObject *
 GMPy_MPZ_Function_PrevPrime(PyObject *self, PyObject *other)
 {
-    #if (__GNU_MP_VERSION > 6) || (__GNU_MP_VERSION == 6 &&  __GNU_MP_VERSION_MINOR >= 3)
         MPZ_Object *result;
 
         if(MPZ_Check(other)) {
@@ -1520,8 +1521,9 @@ GMPy_MPZ_Function_PrevPrime(PyObject *self, PyObject *other)
                 /* LCOV_EXCL_STOP */
             }
             if (!mpz_prevprime(result->z, MPZ(other))) {
-                /* no previous prime, default to 2 in this case */
-                mpz_set_ui(result->z, 2);
+                /* no previous prime, raise value error. */
+                VALUE_ERROR("x must be >= 3");
+                return NULL;
             }
         }
         else {
@@ -1531,16 +1533,15 @@ GMPy_MPZ_Function_PrevPrime(PyObject *self, PyObject *other)
             }
             else {
                 if (!mpz_prevprime(result->z, result->z)) {
-                    /* no previous prime, default to 2 in this case */
-                    mpz_set_ui(result->z, 2);
+                    /* no previous prime, raise value error. */
+                    VALUE_ERROR("x must be >= 3");
+                    return NULL;
                 }
             }
         }
         return (PyObject*)result;
-    #endif
-
-    Py_RETURN_NOTIMPLEMENTED;
 }
+#endif
 
 
 PyDoc_STRVAR(GMPy_doc_mpz_function_jacobi,

--- a/src/gmpy2_mpz_misc.c
+++ b/src/gmpy2_mpz_misc.c
@@ -1342,7 +1342,7 @@ GMPy_MPZ_Function_IsPrime(PyObject *self, PyObject *args)
 
     if (mpz_sgn(tempx->z) == -1) {
         Py_DECREF((PyObject*)tempx);
-        Py_RETURN_FALSE;        
+        Py_RETURN_FALSE;
     }
 
     i = mpz_probab_prime_p(tempx->z, (int)reps);
@@ -1386,7 +1386,7 @@ GMPy_MPZ_Method_IsPrime(PyObject *self, PyObject *args)
     }
 
     if (mpz_sgn(MPZ(self)) == -1) {
-        Py_RETURN_FALSE;        
+        Py_RETURN_FALSE;
     }
 
     i = mpz_probab_prime_p(MPZ(self), (int)reps);
@@ -1502,6 +1502,46 @@ GMPy_MPZ_Function_NextPrime(PyObject *self, PyObject *other)
     }
     return (PyObject*)result;
 }
+
+PyDoc_STRVAR(GMPy_doc_mpz_function_prev_prime,
+"prev_prime(x, /) -> mpz\n\n"
+"Return the previous *probable* prime number < x.");
+
+static PyObject *
+GMPy_MPZ_Function_PrevPrime(PyObject *self, PyObject *other)
+{
+    #if (__GNU_MP_VERSION > 6) || (__GNU_MP_VERSION == 6 &&  __GNU_MP_VERSION_MINOR >= 3)
+        MPZ_Object *result;
+
+        if(MPZ_Check(other)) {
+            if(!(result = GMPy_MPZ_New(NULL))) {
+                /* LCOV_EXCL_START */
+                return NULL;
+                /* LCOV_EXCL_STOP */
+            }
+            if (!mpz_prevprime(result->z, MPZ(other))) {
+                /* no previous prime, default to 2 in this case */
+                mpz_set_ui(result->z, 2);
+            }
+        }
+        else {
+            if (!(result = GMPy_MPZ_From_Integer(other, NULL))) {
+                TYPE_ERROR("prev_prime() requires 'mpz' argument");
+                return NULL;
+            }
+            else {
+                if (!mpz_prevprime(result->z, result->z)) {
+                    /* no previous prime, default to 2 in this case */
+                    mpz_set_ui(result->z, 2);
+                }
+            }
+        }
+        return (PyObject*)result;
+    #endif
+
+    Py_RETURN_NOTIMPLEMENTED;
+}
+
 
 PyDoc_STRVAR(GMPy_doc_mpz_function_jacobi,
 "jacobi(x, y, /) -> mpz\n\n"

--- a/src/gmpy2_mpz_misc.h
+++ b/src/gmpy2_mpz_misc.h
@@ -88,6 +88,7 @@ static PyObject * GMPy_MPZ_Function_IsPower(PyObject *self, PyObject *other);
 static PyObject * GMPy_MPZ_Function_IsPrime(PyObject *self, PyObject *args);
 static PyObject * GMPy_MPZ_Function_IsProbabPrime(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
 static PyObject * GMPy_MPZ_Function_NextPrime(PyObject *self, PyObject *other);
+static PyObject * GMPy_MPZ_Function_PrevPrime(PyObject *self, PyObject *other);
 static PyObject * GMPy_MPZ_Function_Jacobi(PyObject *self, PyObject *args);
 static PyObject * GMPy_MPZ_Function_Legendre(PyObject *self, PyObject *args);
 static PyObject * GMPy_MPZ_Function_Kronecker(PyObject *self, PyObject *args);

--- a/src/gmpy2_mpz_misc.h
+++ b/src/gmpy2_mpz_misc.h
@@ -88,7 +88,9 @@ static PyObject * GMPy_MPZ_Function_IsPower(PyObject *self, PyObject *other);
 static PyObject * GMPy_MPZ_Function_IsPrime(PyObject *self, PyObject *args);
 static PyObject * GMPy_MPZ_Function_IsProbabPrime(PyObject *self, PyObject *const *args, Py_ssize_t nargs);
 static PyObject * GMPy_MPZ_Function_NextPrime(PyObject *self, PyObject *other);
+#if (__GNU_MP_VERSION > 6) || (__GNU_MP_VERSION == 6 &&  __GNU_MP_VERSION_MINOR >= 3)
 static PyObject * GMPy_MPZ_Function_PrevPrime(PyObject *self, PyObject *other);
+#endif
 static PyObject * GMPy_MPZ_Function_Jacobi(PyObject *self, PyObject *args);
 static PyObject * GMPy_MPZ_Function_Legendre(PyObject *self, PyObject *args);
 static PyObject * GMPy_MPZ_Function_Kronecker(PyObject *self, PyObject *args);

--- a/test/test_gmpy2_mpz_misc.txt
+++ b/test/test_gmpy2_mpz_misc.txt
@@ -652,8 +652,31 @@ TypeError:
 mpz(3)
 >>> gmpy2.next_prime(2)
 mpz(3)
+>>> gmpy2.next_prime(1000000)
+mpz(1000003)
 >>> gmpy2.next_prime(2357*7069-1) == 2357*7069
 False
+
+Test prev_prime
+---------------
+>>> gmpy2.prev_prime('a')
+Traceback (most recent call last):
+  ...
+TypeError:
+>>> gmpy2.prev_prime(2)
+mpz(2)
+>>> gmpy2.prev_prime(mpz(3))
+mpz(2)
+>>> gmpy2.prev_prime(3)
+mpz(2)
+>>> gmpy2.prev_prime(1000004)
+mpz(1000003)
+>>> gmpy2.prev_prime(1000033)
+mpz(1000003)
+>>> gmpy2.prev_prime(-100)
+mpz(2)
+>>> gmpy2.prev_prime(1)
+mpz(2)
 
 Test iroot
 ----------

--- a/test/test_gmpy2_mpz_misc.txt
+++ b/test/test_gmpy2_mpz_misc.txt
@@ -657,27 +657,6 @@ mpz(1000003)
 >>> gmpy2.next_prime(2357*7069-1) == 2357*7069
 False
 
-Test prev_prime
----------------
->>> gmpy2.prev_prime('a')
-Traceback (most recent call last):
-  ...
-TypeError:
->>> gmpy2.prev_prime(2)
-mpz(2)
->>> gmpy2.prev_prime(mpz(3))
-mpz(2)
->>> gmpy2.prev_prime(3)
-mpz(2)
->>> gmpy2.prev_prime(1000004)
-mpz(1000003)
->>> gmpy2.prev_prime(1000033)
-mpz(1000003)
->>> gmpy2.prev_prime(-100)
-mpz(2)
->>> gmpy2.prev_prime(1)
-mpz(2)
-
 Test iroot
 ----------
 >>> gmpy2.iroot(1,2,3)

--- a/test/test_mpz.py
+++ b/test/test_mpz.py
@@ -5,11 +5,11 @@ from decimal import Decimal
 
 from hypothesis import assume, given, example, settings
 from hypothesis.strategies import booleans, integers, sampled_from
-from pytest import raises
+from pytest import raises, mark
 
 from gmpy2 import (mpz, pack, unpack, cmp, cmp_abs, to_binary, from_binary,
                    random_state, mpz_random, mpz_urandomb, mpz_rrandomb,
-                   prev_prime)
+                   prev_prime, mp_version)
 from supportclasses import a, b, c, d, z, q
 
 
@@ -311,7 +311,7 @@ def test_mpz_rrandomb():
     assert (mpz_rrandomb(random_state(42), 64).digits(2) ==
             '1111111111111111111111111100000000111111111111111111000000000000')
 
-
+@mark.skipif(mp_version() < "GMP 6.3.0", reason="requires GMP 6.3.0 or higher")
 def test_prev_prime():
     assert prev_prime(3) == mpz(2)
     assert prev_prime(4) == mpz(3)

--- a/test/test_mpz.py
+++ b/test/test_mpz.py
@@ -8,7 +8,8 @@ from hypothesis.strategies import booleans, integers, sampled_from
 from pytest import raises
 
 from gmpy2 import (mpz, pack, unpack, cmp, cmp_abs, to_binary, from_binary,
-                   random_state, mpz_random, mpz_urandomb, mpz_rrandomb)
+                   random_state, mpz_random, mpz_urandomb, mpz_rrandomb,
+                   prev_prime)
 from supportclasses import a, b, c, d, z, q
 
 
@@ -309,3 +310,24 @@ def test_mpz_urandomb():
 def test_mpz_rrandomb():
     assert (mpz_rrandomb(random_state(42), 64).digits(2) ==
             '1111111111111111111111111100000000111111111111111111000000000000')
+
+
+def test_prev_prime():
+    assert prev_prime(3) == mpz(2)
+    assert prev_prime(4) == mpz(3)
+    assert prev_prime(5) == mpz(3)
+    assert prev_prime(6) == mpz(5)
+    assert prev_prime(1000004) == mpz(1000003)
+    assert prev_prime(1000033) == mpz(1000003)
+
+    with raises(ValueError):
+        prev_prime(-100)
+
+    with raises(ValueError):
+        prev_prime(2)
+
+    with raises(TypeError):
+        prev_prime('a')
+
+    with raises(TypeError):
+        prev_prime(4.5)

--- a/test/test_mpz.py
+++ b/test/test_mpz.py
@@ -9,7 +9,7 @@ from pytest import raises, mark
 
 from gmpy2 import (mpz, pack, unpack, cmp, cmp_abs, to_binary, from_binary,
                    random_state, mpz_random, mpz_urandomb, mpz_rrandomb,
-                   prev_prime, mp_version)
+                   mp_version)
 from supportclasses import a, b, c, d, z, q
 
 
@@ -313,6 +313,8 @@ def test_mpz_rrandomb():
 
 @mark.skipif(mp_version() < "GMP 6.3.0", reason="requires GMP 6.3.0 or higher")
 def test_prev_prime():
+    # Imported here as symbol won't exist if mp_version() < 6.3.0
+    from gmpy2 import prev_prime
     assert prev_prime(3) == mpz(2)
     assert prev_prime(4) == mpz(3)
     assert prev_prime(5) == mpz(3)

--- a/test/test_mpz_functions.txt
+++ b/test/test_mpz_functions.txt
@@ -523,6 +523,9 @@ Test gmpy2.mul_2exp
 Test gmpy2.next_prime
 ---------------------
 
+Test gmpy2.prev_prime
+---------------------
+
 Test gmpy2.numdigits
 --------------------
 

--- a/test/test_mpz_functions.txt
+++ b/test/test_mpz_functions.txt
@@ -523,9 +523,6 @@ Test gmpy2.mul_2exp
 Test gmpy2.next_prime
 ---------------------
 
-Test gmpy2.prev_prime
----------------------
-
 Test gmpy2.numdigits
 --------------------
 


### PR DESCRIPTION
I authored `mpz_prevprime` and finally got it upstreamed. I'd love if gmpy2 would also support this (as I mostly call gmp via your wonderful wrapper).

Couple of notes
* I throw `Py_RETURN_NOTIMPLEMENTED` if `__GNU_MP_VERSION < 6.3`
I'm not sure when gmp 6.3 release will happen but this is the safest option. I/you/others can always remove this line (or change it to 6.2) when using development version of the repo which uses build version 6.2.99.
* mpz_prevprime has an int return (0 when no previous prime (arg < 2), definite prime, probable prime) I can return a two element tuple but IMHO it's better to just return the previous_prime (or 2).