### PR TITLE
Allow threads in certain mpz operations, subject to a flag

### DIFF
--- a/src/gmpy2.h
+++ b/src/gmpy2.h
@@ -171,6 +171,7 @@ typedef struct {
     mpfr_rnd_t imag_round;   /* current rounding mode for Im(MPC) */
     int allow_complex;       /* if 1, allow mpfr functions to return an mpc */
     int rational_division;   /* if 1, mpz/mpz returns an mpq result */
+    int allow_release_gil;   /* if 1, allow mpz functions to release the GIL */
 } gmpy_context;
 
 typedef struct {

--- a/src/gmpy2_add.c
+++ b/src/gmpy2_add.c
@@ -46,7 +46,9 @@ GMPy_Integer_AddWithType(PyObject *x, int xtype, PyObject *y, int ytype,
 
     if (IS_TYPE_MPZANY(xtype)) {
         if (IS_TYPE_MPZANY(ytype)) {
+            GMPY_MAYBE_BEGIN_ALLOW_THREADS(context);
             mpz_add(result->z, MPZ(x), MPZ(y));
+            GMPY_MAYBE_END_ALLOW_THREADS(context);
             return (PyObject*)result;
         }
 

--- a/src/gmpy2_context.c
+++ b/src/gmpy2_context.c
@@ -82,6 +82,7 @@ GMPy_CTXT_New(void)
         result->ctx.imag_round = -1;
         result->ctx.allow_complex = 0;
         result->ctx.rational_division = 0;
+        result->ctx.allow_release_gil = 0;
 
 #ifndef WITHOUT_THREADS
         result->tstate = NULL;
@@ -353,7 +354,7 @@ GMPy_CTXT_Repr_Slot(CTXT_Object *self)
     PyObject *result = NULL;
     int i = 0;
 
-    tuple = PyTuple_New(23);
+    tuple = PyTuple_New(24);
     if (!tuple)
         return NULL;
 
@@ -369,7 +370,8 @@ GMPy_CTXT_Repr_Slot(CTXT_Object *self)
             "        trap_erange=%s, erange=%s,\n"
             "        trap_divzero=%s, divzero=%s,\n"
             "        allow_complex=%s,\n"
-            "        rational_division=%s)"
+            "        rational_division=%s,\n"
+            "        allow_release_gil=%s)"
             );
     if (!format) {
         Py_DECREF(tuple);
@@ -405,6 +407,7 @@ GMPy_CTXT_Repr_Slot(CTXT_Object *self)
     PyTuple_SET_ITEM(tuple, i++, PyBool_FromLong(self->ctx.divzero));
     PyTuple_SET_ITEM(tuple, i++, PyBool_FromLong(self->ctx.allow_complex));
     PyTuple_SET_ITEM(tuple, i++, PyBool_FromLong(self->ctx.rational_division));
+    PyTuple_SET_ITEM(tuple, i++, PyBool_FromLong(self->ctx.allow_release_gil));
 
     if (!PyErr_Occurred())
         result = Py2or3String_Format(format, tuple);
@@ -466,7 +469,7 @@ _parse_context_args(CTXT_Object *ctxt, PyObject *kwargs)
         "real_round", "imag_round", "emax", "emin", "subnormalize",
         "trap_underflow", "trap_overflow", "trap_inexact",
         "trap_invalid", "trap_erange", "trap_divzero", "allow_complex",
-        "rational_division", NULL };
+        "rational_division", "allow_release_gil", NULL };
 
     /* Create an empty dummy tuple to use for args. */
 
@@ -485,7 +488,7 @@ _parse_context_args(CTXT_Object *ctxt, PyObject *kwargs)
     x_trap_divzero = ctxt->ctx.traps & TRAP_DIVZERO;
 
     if (!(PyArg_ParseTupleAndKeywords(args, kwargs,
-            "|llliiilliiiiiiiii", kwlist,
+            "|llliiilliiiiiiiiii", kwlist,
             &ctxt->ctx.mpfr_prec,
             &ctxt->ctx.real_prec,
             &ctxt->ctx.imag_prec,
@@ -502,7 +505,8 @@ _parse_context_args(CTXT_Object *ctxt, PyObject *kwargs)
             &x_trap_erange,
             &x_trap_divzero,
             &ctxt->ctx.allow_complex,
-            &ctxt->ctx.rational_division))) {
+            &ctxt->ctx.rational_division,
+            &ctxt->ctx.allow_release_gil))) {
         VALUE_ERROR("invalid keyword arguments for context");
         Py_DECREF(args);
         return 0;
@@ -686,7 +690,9 @@ PyDoc_STRVAR(GMPy_doc_context,
 "    allow_complex:     if True, allow mpfr functions to return mpc\n"
 "                       if False, mpfr functions cannot return an mpc\n"
 "    rational_division: if True, mpz/mpz returns an mpq\n"
-"                       if False, mpz/mpz follows default behavior\n");
+"                       if False, mpz/mpz follows default behavior\n"
+"    allow_release_gil: if True, mpq operations may release the GIL\n"
+"                       if False, mpq operations may not release the GIL\n");
 #if 0
 "\nMethods\n"
 "    abs(x)          return absolute value of x\n"
@@ -950,6 +956,7 @@ GETSET_BOOLEAN_BIT(trap_erange, TRAP_ERANGE);
 GETSET_BOOLEAN_BIT(trap_divzero, TRAP_DIVZERO);
 GETSET_BOOLEAN(allow_complex)
 GETSET_BOOLEAN(rational_division)
+GETSET_BOOLEAN(allow_release_gil)
 
 static PyObject *
 GMPy_CTXT_Get_precision(CTXT_Object *self, void *closure)
@@ -1221,6 +1228,7 @@ static PyGetSetDef GMPyContext_getseters[] = {
     ADD_GETSET(trap_divzero),
     ADD_GETSET(allow_complex),
     ADD_GETSET(rational_division),
+    ADD_GETSET(allow_release_gil),
     {NULL}
 };
 

--- a/src/gmpy2_context.h
+++ b/src/gmpy2_context.h
@@ -66,6 +66,8 @@ static PyTypeObject CTXT_Manager_Type;
 
 #define GET_DIV_MODE(c) (c->ctx.rational_division)
 
+#define GET_THREAD_MODE(c) (c->ctx.allow_release_gil)
+
 
 static PyObject *    GMPy_CTXT_Manager_New(void);
 static void          GMPy_CTXT_Manager_Dealloc(CTXT_Manager_Object *self);

--- a/src/gmpy2_context.h
+++ b/src/gmpy2_context.h
@@ -46,8 +46,17 @@ static PyTypeObject CTXT_Manager_Type;
 
 #ifdef WITHOUT_THREADS
 #define CURRENT_CONTEXT(obj) obj = module_context;
+#define GMPY_MAYBE_BEGIN_ALLOW_THREADS /* NOTHING */
+#define GMPY_MAYBE_ALLOW_THREADS do {} while(0)
 #else
 #define CURRENT_CONTEXT(obj) obj = GMPy_current_context();
+#define GMPY_MAYBE_BEGIN_ALLOW_THREADS(context) { \
+        PyThreadState *_save; \
+        CHECK_CONTEXT(context); \
+        _save = GET_THREAD_MODE(context) ? PyEval_SaveThread() : NULL;
+#define GMPY_MAYBE_END_ALLOW_THREADS(context) \
+        if (_save) PyEval_RestoreThread(_save); \
+    }
 #endif
 
 #define CHECK_CONTEXT(context) \

--- a/src/gmpy2_divmod.c
+++ b/src/gmpy2_divmod.c
@@ -49,7 +49,9 @@ GMPy_Integer_DivModWithType(PyObject *x, int xtype, PyObject *y, int ytype,
                 ZERO_ERROR("division or modulo by zero");
                 goto error;
             }
+            GMPY_MAYBE_BEGIN_ALLOW_THREADS(context);
             mpz_fdiv_qr(quo->z, rem->z, MPZ(x), MPZ(y));
+            GMPY_MAYBE_END_ALLOW_THREADS(context);
             PyTuple_SET_ITEM(result, 0, (PyObject*)quo);
             PyTuple_SET_ITEM(result, 1, (PyObject*)rem);
             return result;

--- a/src/gmpy2_floordiv.c
+++ b/src/gmpy2_floordiv.c
@@ -47,7 +47,9 @@ GMPy_Integer_FloorDivWithType(PyObject *x, int xtype, PyObject *y, int ytype,
                 Py_DECREF((PyObject*)result);
                 return NULL;
             }
+            GMPY_MAYBE_BEGIN_ALLOW_THREADS(context);
             mpz_fdiv_q(result->z, MPZ(x), MPZ(y));
+            GMPY_MAYBE_END_ALLOW_THREADS(context);
             return (PyObject*)result;
         }
 

--- a/src/gmpy2_mul.c
+++ b/src/gmpy2_mul.c
@@ -45,7 +45,9 @@ GMPy_Integer_MulWithType(PyObject *x, int xtype, PyObject *y, int ytype,
 
     if (IS_TYPE_MPZANY(xtype)) {
         if (IS_TYPE_MPZANY(ytype)) {
+            GMPY_MAYBE_BEGIN_ALLOW_THREADS(context);
             mpz_mul(result->z, MPZ(x), MPZ(y));
+            GMPY_MAYBE_END_ALLOW_THREADS(context);
             return (PyObject*)result;
         }
 

--- a/test/test_context.txt
+++ b/test/test_context.txt
@@ -19,7 +19,8 @@ context(precision=24, real_prec=Default, imag_prec=Default,
         trap_erange=False, erange=False,
         trap_divzero=False, divzero=False,
         allow_complex=False,
-        rational_division=False)
+        rational_division=False,
+        allow_release_gil=False)
 >>> ieee(64)
 context(precision=53, real_prec=Default, imag_prec=Default,
         round=RoundToNearest, real_round=Default, imag_round=Default,
@@ -32,7 +33,8 @@ context(precision=53, real_prec=Default, imag_prec=Default,
         trap_erange=False, erange=False,
         trap_divzero=False, divzero=False,
         allow_complex=False,
-        rational_division=False)
+        rational_division=False,
+        allow_release_gil=False)
 >>> ieee(128)
 context(precision=113, real_prec=Default, imag_prec=Default,
         round=RoundToNearest, real_round=Default, imag_round=Default,
@@ -45,7 +47,8 @@ context(precision=113, real_prec=Default, imag_prec=Default,
         trap_erange=False, erange=False,
         trap_divzero=False, divzero=False,
         allow_complex=False,
-        rational_division=False)
+        rational_division=False,
+        allow_release_gil=False)
 >>> gmpy2.ieee(256)
 context(precision=237, real_prec=Default, imag_prec=Default,
         round=RoundToNearest, real_round=Default, imag_round=Default,
@@ -58,7 +61,8 @@ context(precision=237, real_prec=Default, imag_prec=Default,
         trap_erange=False, erange=False,
         trap_divzero=False, divzero=False,
         allow_complex=False,
-        rational_division=False)
+        rational_division=False,
+        allow_release_gil=False)
 >>> gmpy2.ieee(-1)
 Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
@@ -92,7 +96,8 @@ context(precision=53, real_prec=Default, imag_prec=Default,
         trap_erange=False, erange=False,
         trap_divzero=False, divzero=False,
         allow_complex=False,
-        rational_division=False)
+        rational_division=False,
+        allow_release_gil=False)
 >>> context(precision=100)
 context(precision=100, real_prec=Default, imag_prec=Default,
         round=RoundToNearest, real_round=Default, imag_round=Default,
@@ -105,7 +110,8 @@ context(precision=100, real_prec=Default, imag_prec=Default,
         trap_erange=False, erange=False,
         trap_divzero=False, divzero=False,
         allow_complex=False,
-        rational_division=False)
+        rational_division=False,
+        allow_release_gil=False)
 >>> context(real_prec=100)
 context(precision=53, real_prec=100, imag_prec=Default,
         round=RoundToNearest, real_round=Default, imag_round=Default,
@@ -118,7 +124,8 @@ context(precision=53, real_prec=100, imag_prec=Default,
         trap_erange=False, erange=False,
         trap_divzero=False, divzero=False,
         allow_complex=False,
-        rational_division=False)
+        rational_division=False,
+        allow_release_gil=False)
 >>> context(real_prec=100,imag_prec=200)
 context(precision=53, real_prec=100, imag_prec=200,
         round=RoundToNearest, real_round=Default, imag_round=Default,
@@ -131,7 +138,8 @@ context(precision=53, real_prec=100, imag_prec=200,
         trap_erange=False, erange=False,
         trap_divzero=False, divzero=False,
         allow_complex=False,
-        rational_division=False)
+        rational_division=False,
+        allow_release_gil=False)
 
 Test get_context()
 ------------------
@@ -149,7 +157,8 @@ context(precision=53, real_prec=Default, imag_prec=Default,
         trap_erange=False, erange=False,
         trap_divzero=False, divzero=False,
         allow_complex=False,
-        rational_division=False)
+        rational_division=False,
+        allow_release_gil=False)
 >>> a=get_context()
 >>> a.precision=100
 >>> a
@@ -164,7 +173,8 @@ context(precision=100, real_prec=Default, imag_prec=Default,
         trap_erange=False, erange=False,
         trap_divzero=False, divzero=False,
         allow_complex=False,
-        rational_division=False)
+        rational_division=False,
+        allow_release_gil=False)
 >>> get_context()
 context(precision=100, real_prec=Default, imag_prec=Default,
         round=RoundToNearest, real_round=Default, imag_round=Default,
@@ -177,7 +187,8 @@ context(precision=100, real_prec=Default, imag_prec=Default,
         trap_erange=False, erange=False,
         trap_divzero=False, divzero=False,
         allow_complex=False,
-        rational_division=False)
+        rational_division=False,
+        allow_release_gil=False)
 >>> b=a.copy()
 >>> b.precision=200
 >>> b
@@ -192,7 +203,8 @@ context(precision=200, real_prec=Default, imag_prec=Default,
         trap_erange=False, erange=False,
         trap_divzero=False, divzero=False,
         allow_complex=False,
-        rational_division=False)
+        rational_division=False,
+        allow_release_gil=False)
 >>> a
 context(precision=100, real_prec=Default, imag_prec=Default,
         round=RoundToNearest, real_round=Default, imag_round=Default,
@@ -205,7 +217,8 @@ context(precision=100, real_prec=Default, imag_prec=Default,
         trap_erange=False, erange=False,
         trap_divzero=False, divzero=False,
         allow_complex=False,
-        rational_division=False)
+        rational_division=False,
+        allow_release_gil=False)
 >>> get_context()
 context(precision=100, real_prec=Default, imag_prec=Default,
         round=RoundToNearest, real_round=Default, imag_round=Default,
@@ -218,7 +231,8 @@ context(precision=100, real_prec=Default, imag_prec=Default,
         trap_erange=False, erange=False,
         trap_divzero=False, divzero=False,
         allow_complex=False,
-        rational_division=False)
+        rational_division=False,
+        allow_release_gil=False)
 
 Test local_context()
 --------------------
@@ -243,7 +257,8 @@ context(precision=53, real_prec=Default, imag_prec=Default,
         trap_erange=False, erange=False,
         trap_divzero=False, divzero=False,
         allow_complex=False,
-        rational_division=False)
+        rational_division=False,
+        allow_release_gil=False)
 >>> with local_context(ieee(64)) as ctx:
 ...   print(ctx)
 ...
@@ -258,7 +273,8 @@ context(precision=53, real_prec=Default, imag_prec=Default,
         trap_erange=False, erange=False,
         trap_divzero=False, divzero=False,
         allow_complex=False,
-        rational_division=False)
+        rational_division=False,
+        allow_release_gil=False)
 >>> get_context()
 context(precision=53, real_prec=Default, imag_prec=Default,
         round=RoundToNearest, real_round=Default, imag_round=Default,
@@ -271,7 +287,8 @@ context(precision=53, real_prec=Default, imag_prec=Default,
         trap_erange=False, erange=False,
         trap_divzero=False, divzero=False,
         allow_complex=False,
-        rational_division=False)
+        rational_division=False,
+        allow_release_gil=False)
 >>> with get_context() as ctx:
 ...   print(ctx.precision)
 ...   ctx.precision+=100
@@ -291,7 +308,8 @@ context(precision=53, real_prec=Default, imag_prec=Default,
         trap_erange=False, erange=False,
         trap_divzero=False, divzero=False,
         allow_complex=False,
-        rational_division=False)
+        rational_division=False,
+        allow_release_gil=False)
 >>> with local_context(precision=200) as ctx:
 ...   print(ctx.precision)
 ...   ctx.precision+=100
@@ -311,6 +329,7 @@ context(precision=53, real_prec=Default, imag_prec=Default,
         trap_erange=False, erange=False,
         trap_divzero=False, divzero=False,
         allow_complex=False,
-        rational_division=False)
+        rational_division=False,
+        allow_release_gil=False)
 
 

--- a/test/test_mpc_create.txt
+++ b/test/test_mpc_create.txt
@@ -20,5 +20,6 @@ context(precision=53, real_prec=Default, imag_prec=Default,
         trap_erange=False, erange=False,
         trap_divzero=False, divzero=False,
         allow_complex=False,
-        rational_division=False)
+        rational_division=False,
+        allow_release_gil=False)
 

--- a/test/test_mpfr_create.txt
+++ b/test/test_mpfr_create.txt
@@ -106,7 +106,8 @@ context(precision=53, real_prec=Default, imag_prec=Default,
         trap_erange=False, erange=False,
         trap_divzero=False, divzero=False,
         allow_complex=False,
-        rational_division=False)
+        rational_division=False,
+        allow_release_gil=False)
 >>> ctx.clear_flags()
 >>> a=mpfr("1.25")
 >>> a.rc
@@ -123,7 +124,8 @@ context(precision=53, real_prec=Default, imag_prec=Default,
         trap_erange=False, erange=False,
         trap_divzero=False, divzero=False,
         allow_complex=False,
-        rational_division=False)
+        rational_division=False,
+        allow_release_gil=False)
 >>> ctx.clear_flags()
 >>> a=mpfr('nan')
 >>> ctx
@@ -138,7 +140,8 @@ context(precision=53, real_prec=Default, imag_prec=Default,
         trap_erange=False, erange=False,
         trap_divzero=False, divzero=False,
         allow_complex=False,
-        rational_division=False)
+        rational_division=False,
+        allow_release_gil=False)
 >>> ctx.clear_flags()
 >>> mpfr(a)
 mpfr('nan')
@@ -154,7 +157,8 @@ context(precision=53, real_prec=Default, imag_prec=Default,
         trap_erange=False, erange=False,
         trap_divzero=False, divzero=False,
         allow_complex=False,
-        rational_division=False)
+        rational_division=False,
+        allow_release_gil=False)
 >>> ctx.clear_flags()
 >>> mpfr(float('nan'))
 mpfr('nan')
@@ -170,7 +174,8 @@ context(precision=53, real_prec=Default, imag_prec=Default,
         trap_erange=False, erange=False,
         trap_divzero=False, divzero=False,
         allow_complex=False,
-        rational_division=False)
+        rational_division=False,
+        allow_release_gil=False)
 
 Create using extended precision
 -------------------------------

--- a/test/test_mpfr_trig.txt
+++ b/test/test_mpfr_trig.txt
@@ -78,7 +78,8 @@ context(precision=100, real_prec=Default, imag_prec=Default,
         trap_erange=False, erange=False,
         trap_divzero=False, divzero=False,
         allow_complex=False,
-        rational_division=False)
+        rational_division=False,
+        allow_release_gil=False)
 
 Test asin
 ---------
@@ -140,7 +141,8 @@ context(precision=100, real_prec=Default, imag_prec=Default,
         trap_erange=False, erange=False,
         trap_divzero=False, divzero=False,
         allow_complex=False,
-        rational_division=False)
+        rational_division=False,
+        allow_release_gil=False)
 
 Test atan
 ---------
@@ -196,7 +198,8 @@ context(precision=100, real_prec=Default, imag_prec=Default,
         trap_erange=False, erange=False,
         trap_divzero=False, divzero=False,
         allow_complex=False,
-        rational_division=False)
+        rational_division=False,
+        allow_release_gil=False)
 
 Test atan2
 ----------
@@ -291,7 +294,8 @@ context(precision=100, real_prec=Default, imag_prec=Default,
         trap_erange=False, erange=False,
         trap_divzero=False, divzero=False,
         allow_complex=False,
-        rational_division=False)
+        rational_division=False,
+        allow_release_gil=False)
 
 Test cot
 --------


### PR DESCRIPTION
As discussed in #291 this allows threads during certain MPZ operations.  The choice is made based on a new flag in the context structure, but not on the characteristics (size) of the numbers involved.

Testing performed:
 * built on Linux with Python 3.7.3
 * Ran `tests/runtests` (some expected output updated)
 * Ran my [fib programs](https://gist.github.com/f3566b4d9222fd29839f1260bbcc0b01), comparing threaded and unthreaded performance in the range where threads are a benefit:
```
$ time python3 fib6.py $((1<<27))  # Threads enabled
134217728: 28049846 digits: 803430834915283969401079…337223560039659570859461

real	0m1.749s
user	0m6.196s
sys	0m0.411s
$ time python3 fib5.py $((1<<27)) # Threads disabled
134217728: 28049846 digits: 803430834915283969401079…337223560039659570859461

real	0m5.777s
user	0m5.386s
sys	0m0.312s
```

The only threaded operation my program performs is "*" of mpz long integers.

I'll look into any CI failures that may occur, and I can add the new begin/end thread macros in other sites you think would be useful to general users. I'm also not sure if there are other testing or documentation tasks I should perform.

I had trouble rebuilding things when I changed the C source.  As I'm not particularly familiar with Python packaging, I expected 'setup.py build' to re-build things, but it does not seem to noticed changed source files. Can you let me know what I'm doing wrong?