### PR TITLE
Use _Py_HashPointer for python 3.10

### DIFF
--- a/src/gmpy2_hash.c
+++ b/src/gmpy2_hash.c
@@ -145,7 +145,12 @@ _mpfr_hash(mpfr_t f)
             }
         }
         else {
+#if PY_VERSION_HEX >= 0x030A00A0
+            // Python 3.10
+            return _Py_HashPointer(f);
+#else
             return _PyHASH_NAN;
+#endif
         }
     }
 


### PR DESCRIPTION
In python 3.10 _PyHASH_NAN was removed and its usage replaced with _Py_HashPointer.

see https://github.com/python/cpython/blob/3.10/Python/pyhash.c#L102