### PR TITLE
Fix #305 v2

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,11 +1,6 @@
 name: Build Wheels
 
-on:
-  push:
-    branches:
-      - master
-    paths:
-      - 'build-wheels.conf'
+on: [push, pull_request]
 
 jobs:
   build_wheels:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -36,6 +36,8 @@ jobs:
           CIBW_PRERELEASE_PYTHONS: True
           CIBW_BEFORE_BUILD: bash scripts/before_ci_build.sh
           CIBW_SKIP: pp*
+          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_24_x86_64
+          CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux_2_24_i686
 
       - uses: actions/upload-artifact@v1
         with:

--- a/scripts/before_ci_build.sh
+++ b/scripts/before_ci_build.sh
@@ -1,20 +1,7 @@
 if [ ! -f finish_before_ci_build ]; then
   if [[ "$OSTYPE" == "linux-gnu" ]]; then
-    # yum install -y wget lzip
-    # wget https://gmplib.org/download/gmp/gmp-6.2.0.tar.lz
-    # tar -xvf gmp-6.2.0.tar.lz
-    # need to set host to the oldest triple to avoid building binaries
-    # that use build machine micro-architecure. configfsf.guess is the one that
-    # comes with autotools which is micro-architecture agnostic.
-    # config.guess is a custom gmp script which knows about micro-architectures.
-    # cd gmp-6.2.0 && ./configure --enable-fat --host=$(./configfsf.guess) && make -j4 && make install && cd ../
-    # wget https://ftp.gnu.org/gnu/mpfr/mpfr-4.1.0.tar.gz
-    # tar -xvf mpfr-4.1.0.tar.gz
-    # cd mpfr-4.1.0 && ./configure && make -j4 && make install && cd ../
-    # wget https://ftp.gnu.org/gnu/mpc/mpc-1.2.1.tar.gz
-    # tar -xvf mpc-1.2.1.tar.gz
-    # cd mpc-1.2.1 && ./configure && make -j4 && make install && cd ../
-    yum install -y libmpc-devel
+    apt update
+    apt install -y libmpc-dev
     pip install Cython
   elif [[ "$OSTYPE" == "darwin"* ]]; then
     brew install gmp mpfr libmpc


### PR DESCRIPTION
@casevh, this is an alternative (uses the Debian image with libmpc-dev version 1.0.3) to #307.  Libraries are ancient enough, however.  For instance, libgmp-dev has version 6.1.2.  #307 uses latest versions.

Second commit is optional, but I think that some testing of building wheels should be done for regular PRs.