### PR TITLE
latest cibuildwheel, curl, not wget, xz, not lz, and wheels for musllinux

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.1.3
+          python -m pip install cibuildwheel==2.3.0
 
       - name: Build wheel
         run: |

--- a/scripts/before_ci_build.sh
+++ b/scripts/before_ci_build.sh
@@ -2,23 +2,18 @@ GMP_VERSION=6.2.1
 MPFR_VERSION=4.1.0
 MPC_VERSION=1.2.1
 if [ ! -f finish_before_ci_build ]; then
-  if [[ "$OSTYPE" == "linux-gnu" || "$OSTYPE" == "darwin"* ]]; then
-    if [ "$OSTYPE" == "linux-gnu" ]; then
-      yum install -y wget lzip
-    else
-      brew install wget
-    fi
-    wget https://gmplib.org/download/gmp/gmp-${GMP_VERSION}.tar.lz
-    tar -xvf gmp-${GMP_VERSION}.tar.lz
+  if [[ "$OSTYPE" == "linux-gnu" || "$OSTYPE" == "linux-musl" || "$OSTYPE" == "darwin"* ]]; then
+    curl -O https://gmplib.org/download/gmp/gmp-${GMP_VERSION}.tar.xz
+    tar -xvf gmp-${GMP_VERSION}.tar.xz
     # need to set host to the oldest triple to avoid building binaries
     # that use build machine micro-architecure. configfsf.guess is the one that
     # comes with autotools which is micro-architecture agnostic.
     # config.guess is a custom gmp script which knows about micro-architectures.
     cd gmp-${GMP_VERSION} && ./configure --enable-fat --host=$(./configfsf.guess) && make -j4 && make install && cd ../
-    wget --no-check-certificate https://ftp.gnu.org/gnu/mpfr/mpfr-${MPFR_VERSION}.tar.gz 
+    curl -O https://www.mpfr.org/mpfr-current/mpfr-${MPFR_VERSION}.tar.gz
     tar -xvf mpfr-${MPFR_VERSION}.tar.gz
     cd mpfr-${MPFR_VERSION} && ./configure && make -j4 && make install && cd ../
-    wget --no-check-certificate https://ftp.gnu.org/gnu/mpc/mpc-${MPC_VERSION}.tar.gz
+    curl -O https://ftp.gnu.org/gnu/mpc/mpc-${MPC_VERSION}.tar.gz
     tar -xvf mpc-${MPC_VERSION}.tar.gz
     cd mpc-${MPC_VERSION} && ./configure && make -j4 && make install && cd ../
     pip install Cython


### PR DESCRIPTION
- bump `cibuildwheel` to the latest version
- Use `.xz` for `GMP` tarball, otherwise some docker images used by `cibuildwheel` don't have good enough tar.
- use `curl` for downloading, it's everywhere, no need to install it (this installation fails on an `i686` docker image).
- Do not skip  `musllinux` (aka `linux-musl`) in the pre-build script.

This gives us
```
gmpy2-2.1.0rc2-cp310-cp310-macosx_10_9_x86_64.whl
gmpy2-2.1.0rc2-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl
gmpy2-2.1.0rc2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
gmpy2-2.1.0rc2-cp310-cp310-musllinux_1_1_i686.whl
gmpy2-2.1.0rc2-cp310-cp310-musllinux_1_1_x86_64.whl
gmpy2-2.1.0rc2-cp36-cp36m-macosx_10_9_x86_64.whl
gmpy2-2.1.0rc2-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl
gmpy2-2.1.0rc2-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
gmpy2-2.1.0rc2-cp36-cp36m-musllinux_1_1_i686.whl
gmpy2-2.1.0rc2-cp36-cp36m-musllinux_1_1_x86_64.whl
gmpy2-2.1.0rc2-cp37-cp37m-macosx_10_9_x86_64.whl
gmpy2-2.1.0rc2-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl
gmpy2-2.1.0rc2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
gmpy2-2.1.0rc2-cp37-cp37m-musllinux_1_1_i686.whl
gmpy2-2.1.0rc2-cp37-cp37m-musllinux_1_1_x86_64.whl
gmpy2-2.1.0rc2-cp38-cp38-macosx_10_9_x86_64.whl
gmpy2-2.1.0rc2-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl
gmpy2-2.1.0rc2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
gmpy2-2.1.0rc2-cp38-cp38-musllinux_1_1_i686.whl
gmpy2-2.1.0rc2-cp38-cp38-musllinux_1_1_x86_64.whl
gmpy2-2.1.0rc2-cp39-cp39-macosx_10_9_x86_64.whl
gmpy2-2.1.0rc2-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl
gmpy2-2.1.0rc2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
gmpy2-2.1.0rc2-cp39-cp39-musllinux_1_1_i686.whl
gmpy2-2.1.0rc2-cp39-cp39-musllinux_1_1_x86_64.whl
```

as the result of the action. Note that this gives us *manylinux_2_17* wheels, as opposed to *manylinux_2_12* provided by cibuildwheel 2.1, so this is an extra.