### PR TITLE
Explicitly link against libm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ extensions = [
     Extension('gmpy2.gmpy2',
               sources=sources,
               include_dirs=['./src'],
-              libraries=['mpc','mpfr','gmp'],
+              libraries=['mpc','mpfr','gmp'] + ([] if ON_WINDOWS else ['m']),
               extra_compile_args=_comp_args,
               )
 ]


### PR DESCRIPTION
The code uses log() which requires this library, but it relied on
Python's own link to this library to resolve the symbol. Making the
requirement explicit is not only more clear, but prevents GNU ld's
--no-undefined option from complaining.