### PR TITLE
Restore cmdclass setup.py option after invalid merge

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,5 +73,6 @@ extensions = [
 cmdclass = {'build_ext': Gmpy2Build}
 
 setup(
+    cmdclass=cmdclass,
     ext_modules=extensions,
 )


### PR DESCRIPTION
@casevh, this is a trivial correction for your merge [535cc25](https://github.com/aleaxit/gmpy/commit/535cc2501bb1a8e245198fbed3f22a52484bfbeb).