### PR TITLE
Revert part of #361 related to arm64 builds (now a separate job again)

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -19,8 +19,31 @@ jobs:
           CIBW_PRERELEASE_PYTHONS: True
           CIBW_SKIP: pp*
           CIBW_BEFORE_BUILD: bash scripts/before_ci_build.sh
-          CIBW_ARCHS_MACOS: "auto arm64"
-          CIBW_TEST_COMMAND: "python {package}/test/runtests.py"
+          CIBW_TEST_COMMAND: python {package}/test/runtests.py
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: ./wheelhouse
+
+  build_wheels_macos_arm64:
+    name: Build wheel on ${{ matrix.os }} arm64
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-12]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build wheel
+        uses: pypa/cibuildwheel@v2.12.0
+        env:
+          CIBW_PRERELEASE_PYTHONS: True
+          CIBW_BEFORE_BUILD: bash scripts/before_ci_build_apple_silicon.sh
+          CIBW_SKIP: pp*
+          CIBW_ARCHS_MACOS: arm64
+          CIBW_TEST_COMMAND: python {package}/test/runtests.py
 
       - uses: actions/upload-artifact@v3
         with:

--- a/scripts/before_ci_build.sh
+++ b/scripts/before_ci_build.sh
@@ -18,7 +18,6 @@ if [ ! -f finish_before_ci_build ]; then
     curl -s -O https://ftp.gnu.org/gnu/mpc/mpc-${MPC_VERSION}.tar.gz
     tar -xf mpc-${MPC_VERSION}.tar.gz
     cd mpc-${MPC_VERSION} && ./configure && make -j4 && make install && cd ../
-    pip install Cython
   fi
   touch finish_before_ci_build
 else

--- a/scripts/before_ci_build_apple_silicon.sh
+++ b/scripts/before_ci_build_apple_silicon.sh
@@ -1,0 +1,30 @@
+GMP_VERSION=6.2.1
+MPFR_VERSION=4.1.1
+MPC_VERSION=1.2.1
+export CPPFLAGS=" --target=arm64-apple-macos11"
+export LDFLAGS=" -arch arm64"
+EXTRA="--build=x86_64-apple-darwin --host=aarch64-apple-darwin --target=aarch64-apple-darwin"
+if [ ! -f finish_before_ci_build ]; then
+  if [[ "$OSTYPE" == "linux-gnu" || "$OSTYPE" == "linux-musl" || "$OSTYPE" == "darwin"* ]]; then
+    echo $PWD
+    curl -O https://ftp.gnu.org/gnu/gmp/gmp-${GMP_VERSION}.tar.xz
+    tar -xf gmp-${GMP_VERSION}.tar.xz
+    cd gmp-${GMP_VERSION}
+    patch -N -Z -p0 < ../scripts/patch-arm64.diff
+    cd ..
+    # need to set host to the oldest triple to avoid building binaries
+    # that use build machine micro-architecure. configfsf.guess is the one that
+    # comes with autotools which is micro-architecture agnostic.
+    # config.guess is a custom gmp script which knows about micro-architectures.
+    cd gmp-${GMP_VERSION} && ./configure $EXTRA --enable-fat && make -j4 && make install && cd ../
+    curl -O -k https://ftp.gnu.org/gnu/mpfr/mpfr-${MPFR_VERSION}.tar.gz
+    tar -xf mpfr-${MPFR_VERSION}.tar.gz
+    cd mpfr-${MPFR_VERSION} && ./configure $EXTRA && make -j4 && make install && cd ../
+    curl -O https://ftp.gnu.org/gnu/mpc/mpc-${MPC_VERSION}.tar.gz
+    tar -xf mpc-${MPC_VERSION}.tar.gz
+    cd mpc-${MPC_VERSION} && ./configure $EXTRA && make -j4 && make install && cd ../
+  fi
+  touch finish_before_ci_build
+else
+  echo "has finished before ci build"
+fi


### PR DESCRIPTION
That reverts part of erroneously merged #361.  No testing for cython integration for wheels yet.

@bebound I'll appreciate your review (wheels testing doesn't work yet on the macos arm64 builds).  For some reason delocate was unable for fix arm64 wheels in #361 or https://github.com/skirpichev/gmpy/tree/fix-arm64.  Now everything was reverted to the previous setup and library files are included in wheels.  It would be nice if we can leave comments on variables in the scripts/before_ci_build_apple_silicon.sh (e.g. LDFLAGS seems to be redundant, as there is ARCHFLAGS).
