### PR TITLE
Implement mpz.as_integer_ratio/to_bytes/from_bytes

### DIFF
--- a/src/gmpy2_mpz.c
+++ b/src/gmpy2_mpz.c
@@ -110,6 +110,7 @@ static PyMethodDef GMPy_MPZ_methods[] = {
     { "num_digits", GMPy_MPZ_Method_NumDigits, METH_VARARGS, GMPy_doc_mpz_method_num_digits },
     { "as_integer_ratio", GMPy_MPZ_Method_As_Integer_Ratio, METH_NOARGS, GMPy_doc_mpz_method_as_integer_ratio },
     { "to_bytes", (PyCFunction)GMPy_MPZ_Method_To_Bytes, METH_VARARGS | METH_KEYWORDS, GMPy_doc_mpz_method_to_bytes },
+    { "from_bytes", (PyCFunction)GMPy_MPZ_Method_From_Bytes, METH_VARARGS | METH_KEYWORDS | METH_CLASS, GMPy_doc_mpz_method_from_bytes },
     { NULL, NULL, 1 }
 };
 

--- a/src/gmpy2_mpz.c
+++ b/src/gmpy2_mpz.c
@@ -108,6 +108,7 @@ static PyMethodDef GMPy_MPZ_methods[] = {
     { "is_prime", GMPy_MPZ_Method_IsPrime, METH_VARARGS, GMPy_doc_mpz_method_is_prime },
     { "is_square", GMPy_MPZ_Method_IsSquare, METH_NOARGS, GMPy_doc_mpz_method_is_square },
     { "num_digits", GMPy_MPZ_Method_NumDigits, METH_VARARGS, GMPy_doc_mpz_method_num_digits },
+    { "as_integer_ratio", GMPy_MPZ_Method_As_Integer_Ratio, METH_NOARGS, GMPy_doc_mpz_method_as_integer_ratio },
     { NULL, NULL, 1 }
 };
 

--- a/src/gmpy2_mpz.c
+++ b/src/gmpy2_mpz.c
@@ -109,6 +109,7 @@ static PyMethodDef GMPy_MPZ_methods[] = {
     { "is_square", GMPy_MPZ_Method_IsSquare, METH_NOARGS, GMPy_doc_mpz_method_is_square },
     { "num_digits", GMPy_MPZ_Method_NumDigits, METH_VARARGS, GMPy_doc_mpz_method_num_digits },
     { "as_integer_ratio", GMPy_MPZ_Method_As_Integer_Ratio, METH_NOARGS, GMPy_doc_mpz_method_as_integer_ratio },
+    { "to_bytes", (PyCFunction)GMPy_MPZ_Method_To_Bytes, METH_VARARGS | METH_KEYWORDS, GMPy_doc_mpz_method_to_bytes },
     { NULL, NULL, 1 }
 };
 

--- a/src/gmpy2_mpz_misc.c
+++ b/src/gmpy2_mpz_misc.c
@@ -1740,6 +1740,17 @@ GMPy_MPZ_Attrib_GetDenom(MPZ_Object *self, void *closure)
     return (PyObject*)result;
 }
 
+PyDoc_STRVAR(GMPy_doc_mpz_method_as_integer_ratio,
+"x.as_integer_ratio() -> tuple[mpz, mpz]\n\n"
+"Return a pair of integers, whose ratio is exactly equal to the\n"
+"original number and with a positive denominator.");
+static PyObject *
+GMPy_MPZ_Method_As_Integer_Ratio(PyObject *self, PyObject *args)
+{
+    return PyTuple_Pack(2, GMPy_MPZ_Attrib_GetNumer((MPZ_Object*)self, NULL),
+                        GMPy_MPZ_Attrib_GetDenom((MPZ_Object*)self, NULL));
+}
+
 static PyObject *
 GMPy_MPZ_Attrib_GetImag(MPZ_Object *self, void *closure)
 {

--- a/src/gmpy2_mpz_misc.h
+++ b/src/gmpy2_mpz_misc.h
@@ -41,6 +41,7 @@ static PyObject * GMPy_MPZ_Attrib_GetImag(MPZ_Object *self, void *closure);
 
 static PyObject * GMPy_MPZ_Method_As_Integer_Ratio(PyObject *self, PyObject *args);
 static PyObject * GMPy_MPZ_Method_To_Bytes(PyObject *self, PyObject *args, PyObject *kwds);
+static PyObject * GMPy_MPZ_Method_From_Bytes(PyTypeObject *type, PyObject *args, PyObject *kwds);
 
 static PyObject * GMPy_MPZ_Method_Ceil(PyObject *self, PyObject *other);
 static PyObject * GMPy_MPZ_Method_Floor(PyObject *self, PyObject *other);

--- a/src/gmpy2_mpz_misc.h
+++ b/src/gmpy2_mpz_misc.h
@@ -39,6 +39,8 @@ static PyObject * GMPy_MPZ_Attrib_GetDenom(MPZ_Object *self, void *closure);
 static PyObject * GMPy_MPZ_Attrib_GetReal(MPZ_Object *self, void *closure);
 static PyObject * GMPy_MPZ_Attrib_GetImag(MPZ_Object *self, void *closure);
 
+static PyObject * GMPy_MPZ_Method_As_Integer_Ratio(PyObject *self, PyObject *args);
+
 static PyObject * GMPy_MPZ_Method_Ceil(PyObject *self, PyObject *other);
 static PyObject * GMPy_MPZ_Method_Floor(PyObject *self, PyObject *other);
 static PyObject * GMPy_MPZ_Method_Trunc(PyObject *self, PyObject *other);

--- a/src/gmpy2_mpz_misc.h
+++ b/src/gmpy2_mpz_misc.h
@@ -40,6 +40,7 @@ static PyObject * GMPy_MPZ_Attrib_GetReal(MPZ_Object *self, void *closure);
 static PyObject * GMPy_MPZ_Attrib_GetImag(MPZ_Object *self, void *closure);
 
 static PyObject * GMPy_MPZ_Method_As_Integer_Ratio(PyObject *self, PyObject *args);
+static PyObject * GMPy_MPZ_Method_To_Bytes(PyObject *self, PyObject *args, PyObject *kwds);
 
 static PyObject * GMPy_MPZ_Method_Ceil(PyObject *self, PyObject *other);
 static PyObject * GMPy_MPZ_Method_Floor(PyObject *self, PyObject *other);

--- a/test/test_gmpy2_mpz_misc.txt
+++ b/test/test_gmpy2_mpz_misc.txt
@@ -774,6 +774,11 @@ Test denominator
 >>> a.denominator
 mpz(1)
 
+Test as_integer_ratio
+---------------------
+>>> gmpy2.mpz(3).as_integer_ratio()
+(mpz(3), mpz(1))
+
 Test underscore
 ---------------
 >>> mpz('1_2')

--- a/test/test_gmpy2_mpz_misc.txt
+++ b/test/test_gmpy2_mpz_misc.txt
@@ -813,6 +813,28 @@ b'\xff\xfc\x18'
 >>> mpz(-1000).to_bytes(length=3, byteorder='little', signed=True)
 b'\x18\xfc\xff'
 
+Test from_bytes
+---------------
+
+>>> mpz.from_bytes(int(10).to_bytes(1, 'big'))
+mpz(10)
+>>> mpz.from_bytes(int(-10).to_bytes(1, 'big', signed=True), signed=True)
+mpz(-10)
+>>> mpz.from_bytes(int(-12).to_bytes(1, 'big', signed=True), signed=True)
+mpz(-12)
+>>> mpz.from_bytes(int(-112).to_bytes(1, 'big', signed=True), signed=True)
+mpz(-112)
+>>> mpz.from_bytes(int(-122).to_bytes(1, 'big', signed=True), signed=True)
+mpz(-122)
+>>> mpz.from_bytes(int(-122).to_bytes(length=2, byteorder='big', signed=True), signed=True)
+mpz(-122)
+>>> mpz.from_bytes(int(-122).to_bytes(length=2, byteorder='little', signed=True), signed=True)
+mpz(-30977)
+>>> mpz.from_bytes(int(-122).to_bytes(length=2, byteorder='little', signed=True), byteorder='little', signed=True)
+mpz(-122)
+>>> mpz.from_bytes(mpz(-122).to_bytes(length=2, byteorder='little', signed=True), byteorder='little', signed=True)
+mpz(-122)
+
 Test underscore
 ---------------
 >>> mpz('1_2')

--- a/test/test_gmpy2_mpz_misc.txt
+++ b/test/test_gmpy2_mpz_misc.txt
@@ -779,6 +779,40 @@ Test as_integer_ratio
 >>> gmpy2.mpz(3).as_integer_ratio()
 (mpz(3), mpz(1))
 
+Test to_bytes
+-------------
+
+>>> mpz(1000).to_bytes()  # doctest: +IGNORE_EXCEPTION_DETAIL +ELLIPSIS
+Traceback (most recent call last):
+..
+OverflowError: int too big to convert
+>>> mpz(1000).to_bytes(2)
+b'\x03\xe8'
+>>> mpz(1000).to_bytes(length=2)
+b'\x03\xe8'
+>>> mpz(1000).to_bytes(length=2, byteorder='little')
+b'\xe8\x03'
+>>> mpz(-1000).to_bytes(length=2)  # doctest: +IGNORE_EXCEPTION_DETAIL +ELLIPSIS
+Traceback (most recent call last):
+..
+OverflowError: can't convert negative int to unsigned
+>>> mpz(-1000).to_bytes(length=2, signed=True)
+b'\xfc\x18'
+>>> mpz(-1000).to_bytes(length=2, byteorder='little', signed=True)
+b'\x18\xfc'
+>>> mpz(-1000).to_bytes(length=2, byteorder='spam', signed=True)  # doctest: +IGNORE_EXCEPTION_DETAIL +ELLIPSIS
+Traceback (most recent call last):
+...
+ValueError: byteorder must be either 'little' or 'big'
+>>> mpz(1000).to_bytes(length=3)
+b'\x00\x03\xe8'
+>>> mpz(1000).to_bytes(length=3, byteorder='little')
+b'\xe8\x03\x00'
+>>> mpz(-1000).to_bytes(length=3, signed=True)
+b'\xff\xfc\x18'
+>>> mpz(-1000).to_bytes(length=3, byteorder='little', signed=True)
+b'\x18\xfc\xff'
+
 Test underscore
 ---------------
 >>> mpz('1_2')


### PR DESCRIPTION
Should fix #357.  Early draft version, please don't merge unless absolutely sure.

Some benchmarks are [here](https://github.com/aleaxit/gmpy/issues/357#issuecomment-1411329795).  But note that for this size integers - arguments parsing (PyArg_ParseTupleAndKeywords branch) take ~1/3 of time.  Without this branch:
```
$ python -m timeit -s 'from gmpy2 import fac' -s 'a = fac(57)' 'a.to_bytes(32)'
500000 loops, best of 5: 548 nsec per loop
```
