### PR TITLE
Enable printing command input lines in scripts/before*.sh

### DIFF
--- a/scripts/before_ci_build.sh
+++ b/scripts/before_ci_build.sh
@@ -1,12 +1,10 @@
-set -e
+set -e -x
 
 GMP_VERSION=6.2.1
 MPFR_VERSION=4.1.1
 MPC_VERSION=1.2.1
 if [ ! -f finish_before_ci_build ]; then
   if [[ "$OSTYPE" == "linux-gnu" || "$OSTYPE" == "linux-musl" || "$OSTYPE" == "darwin"* ]]; then
-	echo "Run scripts/before_ci_build.sh on $OSTYPE"
-    set
     curl -s -O https://ftp.gnu.org/gnu/gmp/gmp-${GMP_VERSION}.tar.xz
     tar -xf gmp-${GMP_VERSION}.tar.xz
     cd gmp-${GMP_VERSION}

--- a/scripts/before_ci_build_apple_silicon.sh
+++ b/scripts/before_ci_build_apple_silicon.sh
@@ -1,3 +1,5 @@
+set -e -x
+
 GMP_VERSION=6.2.1
 MPFR_VERSION=4.1.1
 MPC_VERSION=1.2.1
@@ -6,7 +8,6 @@ export LDFLAGS=" -arch arm64"
 EXTRA="--build=x86_64-apple-darwin --host=aarch64-apple-darwin --target=aarch64-apple-darwin"
 if [ ! -f finish_before_ci_build ]; then
   if [[ "$OSTYPE" == "linux-gnu" || "$OSTYPE" == "linux-musl" || "$OSTYPE" == "darwin"* ]]; then
-    echo $PWD
     curl -O https://ftp.gnu.org/gnu/gmp/gmp-${GMP_VERSION}.tar.xz
     tar -xf gmp-${GMP_VERSION}.tar.xz
     cd gmp-${GMP_VERSION}


### PR DESCRIPTION
An example:
https://github.com/aleaxit/gmpy/actions/runs/4060983530/jobs/6990590195
It's not clear what's was failing: curl (probably it is and --retry option may be useful) or tar.

Cleanup some debugging echo/set calls.