### PR TITLE
Enable coverage testing in CI

### DIFF
--- a/.github/workflows/pip_install_gmpy2.yml
+++ b/.github/workflows/pip_install_gmpy2.yml
@@ -46,7 +46,7 @@ jobs:
           python setup.py clean
           CFLAGS="-coverage" python setup.py develop
           python test/runtests.py
-          lcov --capture --directory . --output-file build/coverage.info
+          lcov --capture --directory . --no-external --output-file build/coverage.info
           genhtml build/coverage.info --output-directory build/coverage
       - name: Archive build artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/pip_install_gmpy2.yml
+++ b/.github/workflows/pip_install_gmpy2.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/setup-python@master
         with:
           python-version: ${{ matrix.python-version }}
-      - run: sudo apt-get install libmpc-dev texlive texlive-latex-extra latexmk
+      - run: sudo apt-get install libmpc-dev texlive texlive-latex-extra latexmk lcov
       - run: pip install --upgrade pip
       - run: pip --verbose install -e .[cython,docs]
       - run: python test/runtests.py
@@ -39,9 +39,19 @@ jobs:
       - run: sphinx-build --color -W --keep-going -b html docs build/sphinx/html
       - run: sphinx-build --color -W --keep-going -b latex docs build/sphinx/latex
       - run: make -C build/sphinx/latex all-pdf
+      - name: Run coverage tests
+        # XXX: why this doesn't work with pip install --editable above?
+        run: |
+          pip uninstall -y gmpy2
+          python setup.py clean
+          CFLAGS="-coverage" python setup.py develop
+          python test/runtests.py
+          lcov --capture --directory . --output-file build/coverage.info
+          genhtml build/coverage.info --output-directory build/coverage
       - name: Archive build artifacts
         uses: actions/upload-artifact@v3
         with:
           path: |
             build/sphinx/html/
             build/sphinx/latex/gmpy2.pdf
+            build/coverage/

--- a/.github/workflows/pip_install_gmpy2.yml
+++ b/.github/workflows/pip_install_gmpy2.yml
@@ -48,6 +48,12 @@ jobs:
           python test/runtests.py
           lcov --capture --directory . --no-external --output-file build/coverage.info
           genhtml build/coverage.info --output-directory build/coverage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          gcov: true
+          gcov_include: src/*.c
+          gcov_args: --no-external
       - name: Archive build artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/test/test_gmpy2_mpz_misc.txt
+++ b/test/test_gmpy2_mpz_misc.txt
@@ -277,6 +277,8 @@ TypeError:
 120
 45
 10
+>>> gmpy2.bincoef(1111111111111111111111, 2)
+mpz(617283950617283950616604938271604938271605)
 
 Test comb
 ---------
@@ -586,6 +588,10 @@ False
 >>> mpz(80**81 + 81**80).is_prime()
 True
 >>> mpz(1234567890).is_prime()
+False
+>>> mpz(-3).is_prime()
+False
+>>> gmpy2.is_prime(-3)
 False
 
 Test next_prime

--- a/test/test_mpz.txt
+++ b/test/test_mpz.txt
@@ -571,3 +571,27 @@ mpz(0)
 >>> a.conjugate()
 mpz(123)
 
+Sequence Protocol
+-----------------
+
+>>> a = mpz(10)
+>>> a[1]
+1
+>>> a[-1]
+1
+>>> a[-2]
+0
+>>> a[0:2]
+mpz(2)
+>>> a[0:3]
+mpz(2)
+>>> a[0:3:-1]
+mpz(0)
+>>> a[111111111111111111111]
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+IndexError: argument too large to convert to an index
+>>> a["spam"]
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+TypeError: bit positions must be integers


### PR DESCRIPTION
* genhtml output stored in the build artifact
* few new coverage tests (seems to be correct, but please check)
* upload coverage results to the codecov.io (that, probably, needs some configuration on your side)