### PR TITLE
Expose context type (was _context) as context (was a function)

### DIFF
--- a/docs/contexts.rst
+++ b/docs/contexts.rst
@@ -3,13 +3,13 @@ Contexts
 
 .. currentmodule:: gmpy2
 
-A *context* (an instance of :class:`_context`) is used to control the behavior
+A `context` type is used to control the behavior
 of :class:`mpfr` and :class:`mpc` arithmetic.  In addition to controlling the
 precision, the rounding mode can be specified, minimum and maximum exponent
 values can be changed, various exceptions can be raised or ignored, gradual
 underflow can be enabled, and returning complex results can be enabled.
 
-:func:`context` creates a new context with all options set to default.
+`context()` creates a new context with all options set to default.
 :func:`set_context` will set the active context.  :func:`get_context` will
 return a reference to the active context. Note that contexts are mutable:
 modifying the reference returned by :func:`get_context` will modify the active
@@ -64,13 +64,12 @@ be discussed later.
 Context Type
 ------------
 
-.. autoclass:: _context
+.. autoclass:: context
    :members:
 
 Context Functions
 -----------------
 
-.. autofunction:: context
 .. autofunction:: get_context
 .. autofunction:: ieee
 .. autofunction:: local_context

--- a/gmpy2/__init__.py
+++ b/gmpy2/__init__.py
@@ -1,5 +1,4 @@
 from .gmpy2 import *
-from .gmpy2 import _context
 # Internal variables/functions are not imported by * above.
 # These are used by some python level functions and are needed
 # at the top level.

--- a/src/gmpy2.c
+++ b/src/gmpy2.c
@@ -818,7 +818,6 @@ static PyMethodDef Pygmpy_methods [] =
     { "const_euler", (PyCFunction)GMPy_Function_Const_Euler, METH_VARARGS | METH_KEYWORDS, GMPy_doc_function_const_euler },
     { "const_log2", (PyCFunction)GMPy_Function_Const_Log2, METH_VARARGS | METH_KEYWORDS, GMPy_doc_function_const_log2 },
     { "const_pi", (PyCFunction)GMPy_Function_Const_Pi, METH_VARARGS | METH_KEYWORDS, GMPy_doc_function_const_pi },
-    { "context", (PyCFunction)GMPy_CTXT_Context, METH_VARARGS | METH_KEYWORDS, GMPy_doc_context },
     { "copy_sign", GMPy_MPFR_copy_sign, METH_VARARGS, GMPy_doc_mpfr_copy_sign },
     { "cos", GMPy_Context_Cos, METH_O, GMPy_doc_function_cos },
     { "cosh", GMPy_Context_Cosh, METH_O, GMPy_doc_function_cosh },
@@ -1158,7 +1157,7 @@ PyMODINIT_FUNC PyInit_gmpy2(void)
     /* Add the context type to the module namespace. */
 
     Py_INCREF(&CTXT_Type);
-    PyModule_AddObject(gmpy_module, "_context", (PyObject*)&CTXT_Type);
+    PyModule_AddObject(gmpy_module, "context", (PyObject*)&CTXT_Type);
 
     /* Add the mpz type to the module namespace. */
 

--- a/src/gmpy2_context.c
+++ b/src/gmpy2_context.c
@@ -716,7 +716,7 @@ PyDoc_STRVAR(GMPy_doc_context,
 #endif
 
 static PyObject *
-GMPy_CTXT_Context(PyObject *self, PyObject *args, PyObject *kwargs)
+GMPy_CTXT_Context(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
     CTXT_Object *result;
 
@@ -1401,7 +1401,7 @@ static PyMethodDef GMPyContext_methods[] =
 static PyTypeObject CTXT_Type =
 {
     PyVarObject_HEAD_INIT(NULL, 0)
-    .tp_name = "gmpy2._context",
+    .tp_name = "gmpy2.context",
     .tp_basicsize = sizeof(CTXT_Object),    
     .tp_dealloc = (destructor) GMPy_CTXT_Dealloc,      
     .tp_repr = (reprfunc) GMPy_CTXT_Repr_Slot,       
@@ -1409,6 +1409,7 @@ static PyTypeObject CTXT_Type =
     .tp_doc = "GMPY2 Context Object",               
     .tp_methods = GMPyContext_methods,                
     .tp_getset = GMPyContext_getseters,                
+    .tp_new = GMPy_CTXT_Context,
 };
 
 static PyMethodDef GMPyContextManager_methods[] =

--- a/src/gmpy2_context.h
+++ b/src/gmpy2_context.h
@@ -97,7 +97,7 @@ static void          GMPy_CTXT_Dealloc(CTXT_Object *self);
 static PyObject *    GMPy_CTXT_Repr_Slot(CTXT_Object *self);
 static PyObject *    GMPy_CTXT_Get(PyObject *self, PyObject *args);
 static PyObject *    GMPy_CTXT_Local(PyObject *self, PyObject *args, PyObject *kwargs);
-static PyObject *    GMPy_CTXT_Context(PyObject *self, PyObject *args, PyObject *kwargs);
+static PyObject *    GMPy_CTXT_Context(PyTypeObject *type, PyObject *args, PyObject *kwargs);
 static PyObject *    GMPy_CTXT_Set(PyObject *self, PyObject *other);
 static PyObject *    GMPy_CTXT_Clear_Flags(PyObject *self, PyObject *args);
 static PyObject *    GMPy_CTXT_Copy(PyObject *self, PyObject *other);


### PR DESCRIPTION
Private _context type was exported in 1b05503 just to show context methods/attributes in docs.