### PR TITLE
Add mpz.to_bytes()/from_bytes()

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -19,6 +19,7 @@ jobs:
           CIBW_PRERELEASE_PYTHONS: True
           CIBW_SKIP: pp*
           CIBW_BEFORE_BUILD: bash scripts/before_ci_build.sh
+          CIBW_TEST_EXTRAS: tests
           CIBW_TEST_COMMAND: python {package}/test/runtests.py
 
       - uses: actions/upload-artifact@v3
@@ -43,6 +44,7 @@ jobs:
           CIBW_BEFORE_BUILD: bash scripts/before_ci_build_apple_silicon.sh
           CIBW_SKIP: pp*
           CIBW_ARCHS_MACOS: arm64
+          CIBW_TEST_EXTRAS: tests
           CIBW_TEST_COMMAND: python {package}/test/runtests.py
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/pip_install_gmpy2.yml
+++ b/.github/workflows/pip_install_gmpy2.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install --upgrade pip
-      - run: pip --verbose install -e .[cython]
+      - run: pip --verbose install -e .[tests]
       - run: python test/runtests.py
       - run: PYTHONPATH=`pwd`/gmpy2 python test_cython/runtests.py
         if: ${{ matrix.python-version == '3.11' }}
@@ -35,7 +35,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: sudo apt-get install libmpc-dev texlive texlive-latex-extra latexmk lcov
       - run: pip install --upgrade pip
-      - run: pip --verbose install -e .[cython,docs]
+      - run: pip --verbose install -e .[docs,tests]
       - run: python test/runtests.py
       - run: PYTHONPATH=`pwd`/gmpy2 python test_cython/runtests.py
       - run: sphinx-build --color -W --keep-going -b doctest docs build/sphinx/doctest

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ docs/_build
 gmpy2.egg-info/
 MANIFEST
 .vscode/
+# Ignore files cached by Hypothesis (including examples directory so far)
+.hypothesis/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ file = 'README.rst'
 content-type = 'text/x-rst'
 [project.optional-dependencies]
 docs = ['sphinx>=4', 'sphinx-rtd-theme>=1']
-cython = ['cython']
+tests = ['pytest', 'hypothesis', 'cython']
 [project.urls]
 Homepage = 'https://github.com/aleaxit/gmpy'
 

--- a/src/gmpy2_mpz.c
+++ b/src/gmpy2_mpz.c
@@ -111,6 +111,7 @@ static PyMethodDef GMPy_MPZ_methods[] = {
     { "is_square", GMPy_MPZ_Method_IsSquare, METH_NOARGS, GMPy_doc_mpz_method_is_square },
     { "num_digits", GMPy_MPZ_Method_NumDigits, METH_VARARGS, GMPy_doc_mpz_method_num_digits },
     { "as_integer_ratio", GMPy_MPZ_Method_As_Integer_Ratio, METH_NOARGS, GMPy_doc_mpz_method_as_integer_ratio },
+    { "to_bytes", (PyCFunction)GMPy_MPZ_Method_To_Bytes, METH_FASTCALL | METH_KEYWORDS, GMPy_doc_mpz_method_to_bytes },
     { NULL, NULL, 1 }
 };
 

--- a/src/gmpy2_mpz.c
+++ b/src/gmpy2_mpz.c
@@ -112,6 +112,7 @@ static PyMethodDef GMPy_MPZ_methods[] = {
     { "num_digits", GMPy_MPZ_Method_NumDigits, METH_VARARGS, GMPy_doc_mpz_method_num_digits },
     { "as_integer_ratio", GMPy_MPZ_Method_As_Integer_Ratio, METH_NOARGS, GMPy_doc_mpz_method_as_integer_ratio },
     { "to_bytes", (PyCFunction)GMPy_MPZ_Method_To_Bytes, METH_FASTCALL | METH_KEYWORDS, GMPy_doc_mpz_method_to_bytes },
+    { "from_bytes", (PyCFunction)GMPy_MPZ_Method_From_Bytes, METH_FASTCALL | METH_KEYWORDS | METH_CLASS, GMPy_doc_mpz_method_from_bytes },
     { NULL, NULL, 1 }
 };
 

--- a/src/gmpy2_mpz_misc.c
+++ b/src/gmpy2_mpz_misc.c
@@ -1796,6 +1796,178 @@ GMPy_MPZ_Method_As_Integer_Ratio(PyObject *self, PyObject *args)
                         GMPy_MPZ_Attrib_GetDenom((MPZ_Object*)self, NULL));
 }
 
+PyDoc_STRVAR(GMPy_doc_mpz_method_to_bytes,
+"x.to_bytes(length=1, byteorder=\'big\', *, signed=False) -> bytes\n\n\
+Return an array of bytes representing an integer.\n\n\
+  length\n\
+    Length of bytes object to use.  An `OverflowError` is raised if the\n\
+    integer is not representable with the given number of bytes.\n\
+  byteorder\n\
+    The byte order used to represent the integer.  If byteorder is\n\
+    \'big\', the most significant byte is at the beginning of the byte\n\
+    array.  If byteorder is \'little\', the most significant byte is at\n\
+    the end of the byte array.  To request the native byte order of the\n\
+    host system, use `sys.byteorder` as the byte order value.\n\
+  signed\n\
+    Determines whether two\'s complement is used to represent the\n\
+    integer.  If signed is `False` and a negative integer is given,\n\
+    an `OverflowError` is raised.");
+static PyObject *
+GMPy_MPZ_Method_To_Bytes(PyObject *self, PyObject *const *args,
+                         Py_ssize_t nargs, PyObject *kwnames)
+{
+    Py_ssize_t i, nkws = 0, size, gap, length = 1;
+    PyObject *bytes, *arg;
+    mpz_t tmp, *pnumber;
+    char *buffer, sign, is_signed = 0, is_negative, is_big, blank = 0;
+    int argidx[2] = {-1, -1};
+    const char *byteorder = NULL, *kwname;
+
+    if (nargs > 2) {
+        TYPE_ERROR("to_bytes() takes at most 2 positional arguments");
+        return NULL;
+    }
+    if (nargs >= 1) {
+        argidx[0] = 0;
+    }
+    if (nargs == 2) {
+        argidx[1] = 1;
+    }
+
+    if (kwnames) {
+        nkws = PyTuple_GET_SIZE(kwnames);
+    }
+    if (nkws > 3) {
+        TYPE_ERROR("to_bytes() takes at most 3 keyword arguments");
+        return NULL;
+    }
+    for (i = 0; i < nkws; i++) {
+        kwname = PyUnicode_AsUTF8(PyTuple_GET_ITEM(kwnames, i));
+        if (strcmp(kwname, "signed") == 0) {
+            is_signed = PyObject_IsTrue(args[nargs + i]);
+        }
+        else if (strcmp(kwname, "length") == 0) {
+            if (nargs == 0) {
+                argidx[0] = nargs + i;
+            }
+            else {
+                TYPE_ERROR("argument for to_bytes() given by name ('length') and position (1)");
+                return NULL;
+            }
+        }
+        else if (strcmp(kwname, "byteorder") == 0) {
+            if (nargs <= 1) {
+                argidx[1] = nargs + i;
+            }
+            else {
+                TYPE_ERROR("argument for to_bytes() given by name ('byteorder') and position (2)");
+                return NULL;
+            }
+        }
+        else {
+            TYPE_ERROR("got an invalid keyword argument for to_bytes()");
+            return NULL;
+        }
+    }
+
+    if (argidx[0] >= 0) {
+        arg = args[argidx[0]];
+        if (PyLong_Check(arg)) {
+            length = PyLong_AsSsize_t(arg);
+        }
+        else {
+            TYPE_ERROR("to_bytes() takes an integer argument 'length'");
+            return NULL;
+        }
+    }
+    if (argidx[1] >= 0) {
+        arg = args[argidx[1]];
+        if (PyUnicode_Check(arg)) {
+            byteorder = PyUnicode_AsUTF8(arg);
+        }
+        else {
+            TYPE_ERROR("to_bytes() argument 'byteorder' must be str");
+            return NULL;
+        }
+    }
+
+    if (length < 0) {
+        VALUE_ERROR("length argument must be non-negative");
+        return NULL;
+    }
+
+    if (byteorder == NULL || strcmp(byteorder, "big") == 0) {
+        is_big = 1;
+    }
+    else if (strcmp(byteorder, "little") == 0) {
+        is_big = 0;
+    }
+    else {
+        VALUE_ERROR("byteorder must be either 'little' or 'big'");
+        return NULL;
+    }
+
+    sign = mpz_sgn(MPZ(self));
+    is_negative = sign < 0;
+    size = mpz_sizeinbase(MPZ(self), 256);
+    pnumber = &MPZ(self);
+
+    if (is_negative) {
+        if (!is_signed) {
+            OVERFLOW_ERROR("can't convert negative mpz to unsigned");
+            return NULL;
+        }
+
+        mpz_init(tmp);
+        mpz_neg(tmp, MPZ(self));
+        mpz_sub_ui(tmp, tmp, 1);
+        sign = mpz_sgn(tmp);
+        pnumber = &tmp;
+    }
+
+    size -= !sign;
+    gap = length - size;
+
+    if ((is_signed && mpz_tstbit(*pnumber, 8*length - 1)) || gap < 0) {
+        OVERFLOW_ERROR("mpz too big to convert");
+        return NULL;
+    }
+
+    if (is_negative) {
+        mpz_ui_pow_ui(tmp, 256, size);
+        mpz_add(tmp, tmp, MPZ(self));
+        blank = 0xff;
+    }
+
+    TEMP_ALLOC(buffer, length);
+
+    if (is_big) {
+        mpz_export(buffer + gap, NULL, 1, sizeof(char), 0, 0, *pnumber);
+        for (i = 0; i < gap; i++) {
+            buffer[i] = blank;
+        }
+    }
+    else {
+        mpz_export(buffer, NULL, -1, sizeof(char), 0, 0, *pnumber);
+        for (i = size; i < length; i++) {
+            buffer[i] = blank;
+        }
+    }
+
+    if (is_negative) {
+        mpz_clear(tmp);
+    }
+
+    bytes = PyBytes_FromStringAndSize(buffer, length);
+    if (bytes == NULL) {
+        return NULL;
+    }
+
+    TEMP_FREE(buffer, length);
+
+    return bytes;
+}
+
 static PyObject *
 GMPy_MPZ_Attrib_GetImag(MPZ_Object *self, void *closure)
 {
@@ -1835,6 +2007,3 @@ GMPy_MP_Method_Conjugate(PyObject *self, PyObject *args)
     Py_INCREF((PyObject*)self);
     return (PyObject*)self;
 }
-
-
-

--- a/src/gmpy2_mpz_misc.h
+++ b/src/gmpy2_mpz_misc.h
@@ -40,6 +40,7 @@ static PyObject * GMPy_MPZ_Attrib_GetReal(MPZ_Object *self, void *closure);
 static PyObject * GMPy_MPZ_Attrib_GetImag(MPZ_Object *self, void *closure);
 
 static PyObject * GMPy_MPZ_Method_As_Integer_Ratio(PyObject *self, PyObject *args);
+static PyObject * GMPy_MPZ_Method_To_Bytes(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames);
 
 static PyObject * GMPy_MPZ_Method_Ceil(PyObject *self, PyObject *other);
 static PyObject * GMPy_MPZ_Method_Floor(PyObject *self, PyObject *other);

--- a/src/gmpy2_mpz_misc.h
+++ b/src/gmpy2_mpz_misc.h
@@ -41,6 +41,7 @@ static PyObject * GMPy_MPZ_Attrib_GetImag(MPZ_Object *self, void *closure);
 
 static PyObject * GMPy_MPZ_Method_As_Integer_Ratio(PyObject *self, PyObject *args);
 static PyObject * GMPy_MPZ_Method_To_Bytes(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames);
+static PyObject * GMPy_MPZ_Method_From_Bytes(PyTypeObject *type, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames);
 
 static PyObject * GMPy_MPZ_Method_Ceil(PyObject *self, PyObject *other);
 static PyObject * GMPy_MPZ_Method_Floor(PyObject *self, PyObject *other);

--- a/test/runtests.py
+++ b/test/runtests.py
@@ -148,6 +148,14 @@ else:
     print("failed")
     failed += 1
 
+print("Running {0:30}  ".format("test_mpz.py"), end="")
+if os.system("pytest " + os.path.dirname(__file__) + "/test_mpz.py") == 0:
+    print("successful")
+    attempted += 1
+else:
+    print("failed")
+    failed += 1
+
 if failed:
     sys.exit(1)
 else:

--- a/test/test_mpz.py
+++ b/test/test_mpz.py
@@ -1,4 +1,4 @@
-from hypothesis import given, example, settings
+from hypothesis import assume, given, example, settings
 from hypothesis.strategies import booleans, integers, sampled_from
 from pytest import raises
 
@@ -63,3 +63,61 @@ def test_to_bytes_mpz_vs_int(x, length, byteorder, signed):
             mpz(x).to_bytes(length, byteorder, signed=signed)
     else:
         assert rx == mpz(x).to_bytes(length, byteorder, signed=signed)
+
+
+def test_mpz_from_bytes_interface():
+    with raises(TypeError):
+        mpz.from_bytes()
+    with raises(TypeError):
+        mpz.from_bytes(1, 2, 3)
+    with raises(TypeError):
+        mpz.from_bytes(b'', 2)
+    with raises(TypeError):
+        mpz.from_bytes(1)
+    with raises(TypeError):
+        mpz.from_bytes(b'', bytes=b'')
+    with raises(TypeError):
+        mpz.from_bytes(b'', 'big', byteorder='big')
+    with raises(TypeError):
+        mpz.from_bytes(b'', spam=1)
+    with raises(TypeError):
+        mpz.from_bytes(a=1, b=2, c=3, d=4)
+
+    with raises(ValueError):
+        mpz.from_bytes(b'', 'spam')
+
+    assert mpz.from_bytes(b'\x01', byteorder='little') == mpz.from_bytes(b'\x01', 'little')
+
+    assert mpz.from_bytes(b'\x01') == mpz.from_bytes(bytes=b'\x01')
+    assert mpz.from_bytes(b'\x01') == mpz.from_bytes(b'\x01', 'big')
+    assert mpz.from_bytes(b'\x01') == mpz.from_bytes(b'\x01', signed=False)
+
+
+@settings(max_examples=1000)
+@given(integers(), integers(min_value=0, max_value=10000),
+       sampled_from(['big', 'little']), booleans())
+@example(0, 0, 'big', False)
+@example(0, 0, 'little', False)
+@example(0, 1, 'big', False)
+@example(128, 1, 'big', True)
+@example(128, 1, 'little', True)
+@example(-129, 1, 'big', True)
+@example(-129, 1, 'little', True)
+@example(-1, 0, 'big', True)
+@example(-1, 1, 'big', True)
+@example(-1, 1, 'little', True)
+@example(-2, 0, 'big', True)
+@example(-2, 0, 'little', True)
+@example(-1, 3, 'big', True)
+@example(-2, 3, 'big', True)
+@example(-2, 5, 'little', True)
+def test_from_bytes_mpz_vs_int(x, length, byteorder, signed):
+    try:
+        bytes = x.to_bytes(length, byteorder, signed=signed)
+    except OverflowError:
+        assume(False)
+    else:
+        rx = int.from_bytes(bytes, byteorder, signed=signed)
+        assert rx == mpz.from_bytes(bytes, byteorder, signed=signed)
+        assert rx == mpz.from_bytes(bytearray(bytes), byteorder, signed=signed)
+        assert rx == mpz.from_bytes(list(bytes), byteorder, signed=signed)

--- a/test/test_mpz.py
+++ b/test/test_mpz.py
@@ -1,0 +1,65 @@
+from hypothesis import given, example, settings
+from hypothesis.strategies import booleans, integers, sampled_from
+from pytest import raises
+
+from gmpy2 import mpz
+
+
+def test_mpz_to_bytes_interface():
+    x = mpz(1)
+    with raises(TypeError):
+        x.to_bytes(1, 2, 3)
+    with raises(TypeError):
+        x.to_bytes(1, 2)
+    with raises(TypeError):
+        x.to_bytes('spam')
+    with raises(TypeError):
+        x.to_bytes(a=1, b=2, c=3, d=4)
+    with raises(TypeError):
+        x.to_bytes(2, length=2)
+    with raises(TypeError):
+        x.to_bytes(2, 'big', byteorder='big')
+    with raises(TypeError):
+        x.to_bytes(spam=1)
+
+    with raises(ValueError):
+        x.to_bytes(2, 'spam')
+    with raises(ValueError):
+        x.to_bytes(-1)
+
+    assert x.to_bytes(2) == x.to_bytes(length=2)
+    assert x.to_bytes(2, byteorder='little') == x.to_bytes(2, 'little')
+
+    assert x.to_bytes() == x.to_bytes(1)
+    assert x.to_bytes() == x.to_bytes(1, 'big')
+    assert x.to_bytes() == x.to_bytes(signed=False)
+
+
+@settings(max_examples=1000)
+@given(integers(), integers(min_value=0, max_value=10000),
+       sampled_from(['big', 'little']), booleans())
+@example(0, 0, 'big', False)
+@example(0, 0, 'little', False)
+@example(0, 1, 'big', False)
+@example(128, 1, 'big', True)
+@example(128, 1, 'little', True)
+@example(-129, 1, 'big', True)
+@example(-129, 1, 'little', True)
+@example(-1, 0, 'big', True)
+@example(-2, 0, 'big', True)
+@example(-2, 0, 'little', True)
+@example(42, 1, 'big', False)
+@example(42, 1, 'little', False)
+@example(42, 3, 'big', False)
+@example(42, 3, 'little', False)
+@example(1000, 2, 'big', False)
+@example(1000, 4, 'big', False)
+@example(-2049, 1, 'big', True)
+def test_to_bytes_mpz_vs_int(x, length, byteorder, signed):
+    try:
+        rx = x.to_bytes(length, byteorder, signed=signed)
+    except OverflowError:
+        with raises(OverflowError):
+            mpz(x).to_bytes(length, byteorder, signed=signed)
+    else:
+        assert rx == mpz(x).to_bytes(length, byteorder, signed=signed)


### PR DESCRIPTION
Closes #357

Some benchmarks:
```
$ python -m timeit -s 'from math import factorial' -s 'a = factorial(57)' 'a.to_bytes(32)'
500000 loops, best of 5: 285 nsec per loop
$ python -m timeit -s 'from gmpy2 import fac' -s 'a = fac(57)' 'a.to_bytes(32)'
500000 loops, best of 5: 486 nsec per loop
$ python -m timeit -s 'from gmpy2 import fac' -s 'a = fac(57)' 'int(a).to_bytes(32)'
500000 loops, best of 5: 823 nsec per loop
```
It seems, int.to_bytes() is slightly better than the mpz_export.

I don't know which formatting should be used for the C code, so PEP 7 is used.  Let me know if I shouldn't use braces for single-line if/for statements or something else.  

BTW, this PR adds an optional dependency on [pytest](https://pytest.org/) and [hypothesis](https://hypothesis.readthedocs.io/), so added bulk tests check that mpz.to_bytes/from_bytes output match int's functions output for same integers.  To always keep some fixed set of tested values (e.g. for code coverage) - the "example" decorator is used.
