### PR TITLE
Add .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+version: 2
+formats:
+    - htmlzip
+    - pdf
+build:
+    os: ubuntu-22.04
+    apt_packages:
+        - libmpc-dev
+        - gcc
+    tools:
+        python: "3"
+python:
+    install:
+        - method: pip
+          path: .
+          extra_requirements:
+              - docs
+sphinx:
+    fail_on_warning: true


### PR DESCRIPTION
Note: I've enabled the docs builds for my fork.  You can take a look here (this fork is up-to-date with your master, except for the commit from this branch): https://gmpy.readthedocs.io/en/latest/
Let me know if it would be better to rename the rtfd project from "gmpy".
BTW, this will fix (https://readthedocs.org/projects/gmpy2/builds/19429488/)