### PR TITLE
pytest: add fixture to reset the current context to defaults

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+import gmpy2
+
+
+@pytest.fixture(autouse=True, scope='module')
+def _set_default_context():
+    gmpy2.set_context(gmpy2.context())


### PR DESCRIPTION
I believe this should fix random failures like [this](https://github.com/aleaxit/gmpy/actions/runs/4943181612/jobs/8837416087).