### PR TITLE
pyproject.toml: Update [build-system] requires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['pip>=20.3', 'setuptools>=61', 'wheel']
+requires = ['setuptools>=61']
 build-backend = 'setuptools.build_meta'
 
 [project]


### PR DESCRIPTION
Removing `pip` and `wheel`, which are not needed.
(for wheel, see https://setuptools.pypa.io/en/latest/userguide/quickstart.html#basic-use)
