### PR TITLE
Skip mpmath test if module not available

### DIFF
--- a/test/test_mpfr.py
+++ b/test/test_mpfr.py
@@ -3,7 +3,6 @@ from decimal import Decimal
 import pytest
 from hypothesis import given, example, settings
 from hypothesis.strategies import floats
-import mpmath
 
 import gmpy2
 from gmpy2 import (gamma_inc, mpfr, cmp, cmp_abs, zero, nan, mpz, mpq,
@@ -123,6 +122,7 @@ def test_mpfr_nrandom():
 
 
 def test_mpfr_mpmath():
+    mpmath = pytest.importorskip("mpmath")
     a, b, c, d = '1.1', '-1.1', '-3.14', '0'
     assert mpfr(a)._mpf_ == (0, mpz(4953959590107546), -52, 53)
     assert mpmath.mpf(mpfr(a)) == mpmath.mpf(a)


### PR DESCRIPTION
Since gmpy2 is a build dependency for mpmath, this allows testing gmpy2 before mpmath is built.