### PR TITLE
Add __version__ module attribute

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,6 +5,8 @@
 # This file is execfile()d with the current directory set to its containing dir.
 
 import sys, os
+import gmpy2
+import packaging.version
 
 if sys.version_info < (3, 9):
     raise RuntimeError("Python version >= 3.9 required to build docs.")
@@ -42,14 +44,16 @@ templates_path = ['_templates']
 project = 'gmpy2'
 copyright = '2012 - 2022, Case Van Horsen'
 
+gmpy2_version = packaging.version.parse(gmpy2.__version__)
+
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
 # The short X.Y version.
-version = '2.2'
+version = f"{gmpy2_version.major}.{gmpy2_version.minor}"
 # The full version, including alpha/beta/rc tags.
-release = '2.2.0a1'
+release = gmpy2.__version__
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/gmpy2/__init__.py
+++ b/gmpy2/__init__.py
@@ -1,4 +1,5 @@
 from .gmpy2 import *
+from .gmpy2 import __version__
 # Internal variables/functions are not imported by * above.
 # These are used by some python level functions and are needed
 # at the top level.

--- a/src/gmpy2.c
+++ b/src/gmpy2.c
@@ -1217,6 +1217,11 @@ PyMODINIT_FUNC PyInit_gmpy2(void)
         return NULL;;
         /* LCOV_EXCL_STOP */
     }
+    if (PyModule_AddStringConstant(gmpy_module, "__version__", gmpy_version) < 0) {
+        /* LCOV_EXCL_START */
+        return NULL;
+        /* LCOV_EXCL_STOP */
+    }
 
     /* Add the exceptions. */
     Py_INCREF(GMPyExc_DivZero);


### PR DESCRIPTION
This is a more standard way to embed version info.  Recognized, e.g. by pytest.importorskip.  

Also, simplify version handling in docs/conf.py.

Probably, we could also deprecate gmpy2.version() function.  @casevh, what do you think?