### PR TITLE
CPython 3.13: add _PyLong_New() and import some macros from pycore_hash.h

### DIFF
--- a/.github/workflows/pip_install_gmpy2.yml
+++ b/.github/workflows/pip_install_gmpy2.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.11, 3.12]
+        python-version: [3.11, 3.12, 3.13]
         os: [macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/src/gmpy2_convert.h
+++ b/src/gmpy2_convert.h
@@ -154,6 +154,44 @@ extern "C" {
 #  define _PyLong_DigitCount(obj) (_PyLong_IsNegative(obj)? -Py_SIZE(obj):Py_SIZE(obj))
 #endif
 
+#if PY_VERSION_HEX >= 0x030D0000
+
+#define MAX_LONG_DIGITS \
+    ((PY_SSIZE_T_MAX - offsetof(PyLongObject, long_value.ob_digit))/sizeof(digit))
+
+PyLongObject *
+_PyLong_New(Py_ssize_t size)
+{
+    assert(size >= 0);
+    PyLongObject *result;
+    if (size > (Py_ssize_t)MAX_LONG_DIGITS) {
+        PyErr_SetString(PyExc_OverflowError,
+                        "too many digits in integer");
+        return NULL;
+    }
+    /* Fast operations for single digit integers (including zero)
+     * assume that there is always at least one digit present. */
+    Py_ssize_t ndigits = size ? size : 1;
+    /* Number of bytes needed is: offsetof(PyLongObject, ob_digit) +
+       sizeof(digit)*size.  Previous incarnations of this code used
+       sizeof() instead of the offsetof, but this risks being
+       incorrect in the presence of padding between the header
+       and the digits. */
+    result = PyObject_Malloc(offsetof(PyLongObject, long_value.ob_digit) +
+                             ndigits*sizeof(digit));
+    if (!result) {
+        PyErr_NoMemory();
+        return NULL;
+    }
+    _PyLong_SetSignAndDigitCount(result, size != 0, size);
+    PyObject_Init((PyObject*)result, &PyLong_Type);
+    /* The digit has to be initialized explicitly to avoid
+     * use-of-uninitialized-value. */
+    result->long_value.ob_digit[0] = 0;
+    return result;
+}
+#endif
+
 /* Since the macros are used in gmpy2's codebase, these functions are skipped
  * until they are needed for the C API in the future.
  */

--- a/src/gmpy2_hash.c
+++ b/src/gmpy2_hash.c
@@ -24,6 +24,11 @@
  * License along with GMPY2; if not, see <http://www.gnu.org/licenses/>    *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+#if PY_VERSION_HEX >= 0x030D0000
+# define Py_BUILD_CORE
+# include <internal/pycore_pyhash.h>
+#endif
+
 static Py_hash_t
 GMPy_MPZ_Hash_Slot(MPZ_Object *self)
 {


### PR DESCRIPTION
Turn on basic tests on 3.13

Closes #417