### PR TITLE
Support negative exponents in mul_2exp

### DIFF
--- a/src/gmpy2_convert_utils.c
+++ b/src/gmpy2_convert_utils.c
@@ -134,64 +134,6 @@ GMPy_Integer_AsUnsignedLongOrLong(PyObject *x, int *is_signed)
     return result;
 }
 
-static unsigned long
-GMPy_Integer_AsUnsignedLongWithType_v2(PyObject *x, int xtype)
-{
-    if IS_TYPE_PyInteger(xtype) {
-        if (_PyLong_IsNegative(((PyLongObject*)x))) {
-            VALUE_ERROR("n must be > 0");
-            return (unsigned long)-1;
-        }
-
-        return PyLong_AsUnsignedLong(x);
-    }
-
-    if (IS_TYPE_MPZANY(xtype)) {
-        if (mpz_sgn(MPZ(x)) < 0) {
-            VALUE_ERROR("n must be > 0");
-            return (unsigned long)-1;
-        }
-
-        if (mpz_fits_ulong_p(MPZ(x))) {
-            return mpz_get_ui(MPZ(x));
-        }
-        else {
-            OVERFLOW_ERROR("value could not be converted to C long");
-            return (unsigned long)-1;
-        }
-    }
-
-    if (IS_TYPE_HAS_MPZ(xtype)) {
-        unsigned long result = 0;
-        PyObject *temp_mpz = PyObject_CallMethod(x, "__mpz__", NULL);
-
-        if ((temp_mpz != NULL) && MPZ_Check(temp_mpz)) {
-            if (mpz_sgn(MPZ(temp_mpz)) < 0) {
-                VALUE_ERROR("n must be > 0");
-                return (unsigned long)-1;
-            }
-
-            if (mpz_fits_ulong_p(MPZ(temp_mpz))) {
-                result = mpz_get_ui(MPZ(temp_mpz));
-            }
-            else {
-                OVERFLOW_ERROR("value could not be converted to C long");
-                result = (unsigned long)-1;
-            }
-        }
-        Py_XDECREF(temp_mpz);
-        return result;
-    }
-    TYPE_ERROR("could not convert object to integer");
-    return (unsigned long)-1;
-}
-
-static unsigned long
-GMPy_Integer_AsUnsignedLong_v2(PyObject *x)
-{
-    return GMPy_Integer_AsUnsignedLongWithType_v2(x, GMPy_ObjectType(x));
-}
-
 #define PY_ABS_LLONG_MIN (0-(unsigned PY_LONG_LONG)PY_LLONG_MIN)
 
 static PY_LONG_LONG

--- a/src/gmpy2_convert_utils.c
+++ b/src/gmpy2_convert_utils.c
@@ -119,6 +119,21 @@ GMPy_Integer_AsUnsignedLong(PyObject *x)
     return GMPy_Integer_AsUnsignedLongWithType(x, GMPy_ObjectType(x));
 }
 
+static long
+GMPy_Integer_AsUnsignedLongOrLong(PyObject *x, int *is_signed)
+{
+    long result = (long)GMPy_Integer_AsUnsignedLong(x);
+    if (result == -1 && PyErr_Occurred()) {
+        *is_signed = 1;
+        PyErr_Clear();
+        result = GMPy_Integer_AsLong(x);
+        if (result == -1 && PyErr_Occurred()) {
+            return -1;
+        }
+    }
+    return result;
+}
+
 static unsigned long
 GMPy_Integer_AsUnsignedLongWithType_v2(PyObject *x, int xtype)
 {

--- a/src/gmpy2_convert_utils.h
+++ b/src/gmpy2_convert_utils.h
@@ -40,8 +40,6 @@ static long            GMPy_Integer_AsLong(PyObject *x);
 static unsigned long   GMPy_Integer_AsUnsignedLongWithType(PyObject *x, int xtype);
 static unsigned long   GMPy_Integer_AsUnsignedLong(PyObject *x);
 static long            GMPy_Integer_AsUnsignedLongOrLong(PyObject *x, int *is_signed);
-static unsigned long   GMPy_Integer_AsUnsignedLongWithType_v2(PyObject *x, int xtype);
-static unsigned long   GMPy_Integer_AsUnsignedLong_v2(PyObject *x);
 
 static PY_LONG_LONG    GMPy_Integer_AsLongLongWithType(PyObject *x, int xtype);
 static PY_LONG_LONG    GMPy_Integer_AsLongLong(PyObject *x);

--- a/src/gmpy2_convert_utils.h
+++ b/src/gmpy2_convert_utils.h
@@ -39,6 +39,7 @@ static long            GMPy_Integer_AsLongWithType(PyObject *x, int xtype);
 static long            GMPy_Integer_AsLong(PyObject *x);
 static unsigned long   GMPy_Integer_AsUnsignedLongWithType(PyObject *x, int xtype);
 static unsigned long   GMPy_Integer_AsUnsignedLong(PyObject *x);
+static long            GMPy_Integer_AsUnsignedLongOrLong(PyObject *x, int *is_signed);
 static unsigned long   GMPy_Integer_AsUnsignedLongWithType_v2(PyObject *x, int xtype);
 static unsigned long   GMPy_Integer_AsUnsignedLong_v2(PyObject *x);
 

--- a/src/gmpy2_mpz_misc.c
+++ b/src/gmpy2_mpz_misc.c
@@ -103,7 +103,7 @@ static PyObject *
 GMPy_MPZ_Function_Iroot(PyObject *self, PyObject *args)
 {
     unsigned long n;
-    int exact;
+    int exact, is_signed = 0;
     MPZ_Object *root = NULL, *tempx = NULL;
     PyObject *result = NULL;
 
@@ -115,8 +115,11 @@ GMPy_MPZ_Function_Iroot(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    n = GMPy_Integer_AsUnsignedLong_v2(PyTuple_GET_ITEM(args, 1));
-    if ((n == 0) || ((n == (unsigned long)(-1)) && PyErr_Occurred())) {
+    n = (unsigned long)GMPy_Integer_AsUnsignedLongOrLong(PyTuple_GET_ITEM(args, 1), &is_signed);
+    if ((n == (unsigned long)(-1)) && PyErr_Occurred()) {
+        return NULL;
+    }
+    if (is_signed || !n) {
         VALUE_ERROR("n must be > 0");
         return NULL;
     }

--- a/src/gmpy2_muldiv_2exp.c
+++ b/src/gmpy2_muldiv_2exp.c
@@ -28,13 +28,19 @@ static PyObject *
 GMPy_Real_Mul_2exp(PyObject *x, PyObject *y, CTXT_Object *context)
 {
     MPFR_Object *result, *tempx;
-    unsigned long exp = 0;
+    long exp = 0;
+    int is_negative = 0;
 
     CHECK_CONTEXT(context);
 
-    exp = GMPy_Integer_AsUnsignedLong(y);
-    if (exp == (unsigned long)(-1) && PyErr_Occurred()) {
-        return NULL;
+    exp = (long)GMPy_Integer_AsUnsignedLong(y);
+    if (exp == -1 && PyErr_Occurred()) {
+        is_negative = 1;
+        PyErr_Clear();
+        exp = GMPy_Integer_AsLong(y);
+        if (exp == -1 && PyErr_Occurred()) {
+            return NULL;
+        }
     }
 
     result = GMPy_MPFR_New(0, context);
@@ -47,7 +53,14 @@ GMPy_Real_Mul_2exp(PyObject *x, PyObject *y, CTXT_Object *context)
 
     mpfr_clear_flags();
 
-    result->rc = mpfr_mul_2ui(result->f, tempx->f, exp, GET_MPFR_ROUND(context));
+    if (is_negative) {
+        result->rc = mpfr_mul_2si(result->f, tempx->f, exp,
+                                  GET_MPFR_ROUND(context));
+    }
+    else {
+        result->rc = mpfr_mul_2ui(result->f, tempx->f, (unsigned long)exp,
+                                  GET_MPFR_ROUND(context));
+    }
     Py_DECREF((PyObject*)tempx);
     _GMPy_MPFR_Cleanup(&result, context);
     return (PyObject*)result;
@@ -57,13 +70,19 @@ static PyObject *
 GMPy_Complex_Mul_2exp(PyObject *x, PyObject *y, CTXT_Object *context)
 {
     MPC_Object *result, *tempx;
-    unsigned long exp = 0;
+    long exp = 0;
+    int is_negative = 0;
 
     CHECK_CONTEXT(context);
 
-    exp = GMPy_Integer_AsUnsignedLong(y);
-    if (exp == (unsigned long)(-1) && PyErr_Occurred()) {
-        return NULL;
+    exp = (long)GMPy_Integer_AsUnsignedLong(y);
+    if (exp == -1 && PyErr_Occurred()) {
+        is_negative = 1;
+        PyErr_Clear();
+        exp = GMPy_Integer_AsLong(y);
+        if (exp == -1 && PyErr_Occurred()) {
+            return NULL;
+        }
     }
 
     result = GMPy_MPC_New(0, 0, context);
@@ -74,7 +93,14 @@ GMPy_Complex_Mul_2exp(PyObject *x, PyObject *y, CTXT_Object *context)
         return NULL;
     }
 
-    result->rc = mpc_mul_2ui(result->c, tempx->c, exp, GET_MPC_ROUND(context));
+    if (is_negative) {
+        result->rc = mpc_mul_2si(result->c, tempx->c, exp,
+                                 GET_MPC_ROUND(context));
+    }
+    else {
+        result->rc = mpc_mul_2ui(result->c, tempx->c, exp,
+                                 GET_MPC_ROUND(context));
+    }
     Py_DECREF((PyObject*)tempx);
     _GMPy_MPC_Cleanup(&result, context);
     return (PyObject*)result;

--- a/src/gmpy2_muldiv_2exp.c
+++ b/src/gmpy2_muldiv_2exp.c
@@ -28,19 +28,14 @@ static PyObject *
 GMPy_Real_Mul_2exp(PyObject *x, PyObject *y, CTXT_Object *context)
 {
     MPFR_Object *result, *tempx;
-    long exp = 0;
-    int is_negative = 0;
+    long exp;
+    int is_signed = 0;
 
     CHECK_CONTEXT(context);
 
-    exp = (long)GMPy_Integer_AsUnsignedLong(y);
+    exp = GMPy_Integer_AsUnsignedLongOrLong(y, &is_signed);
     if (exp == -1 && PyErr_Occurred()) {
-        is_negative = 1;
-        PyErr_Clear();
-        exp = GMPy_Integer_AsLong(y);
-        if (exp == -1 && PyErr_Occurred()) {
-            return NULL;
-        }
+        return NULL;
     }
 
     result = GMPy_MPFR_New(0, context);
@@ -55,7 +50,7 @@ GMPy_Real_Mul_2exp(PyObject *x, PyObject *y, CTXT_Object *context)
 
     mpfr_clear_flags();
 
-    if (is_negative) {
+    if (is_signed) {
         result->rc = mpfr_mul_2si(result->f, tempx->f, exp,
                                   GET_MPFR_ROUND(context));
     }
@@ -72,19 +67,14 @@ static PyObject *
 GMPy_Complex_Mul_2exp(PyObject *x, PyObject *y, CTXT_Object *context)
 {
     MPC_Object *result, *tempx;
-    long exp = 0;
-    int is_negative = 0;
+    long exp;
+    int is_signed = 0;
 
     CHECK_CONTEXT(context);
 
-    exp = (long)GMPy_Integer_AsUnsignedLong(y);
+    exp = GMPy_Integer_AsUnsignedLongOrLong(y, &is_signed);
     if (exp == -1 && PyErr_Occurred()) {
-        is_negative = 1;
-        PyErr_Clear();
-        exp = GMPy_Integer_AsLong(y);
-        if (exp == -1 && PyErr_Occurred()) {
-            return NULL;
-        }
+        return NULL;
     }
 
     result = GMPy_MPC_New(0, 0, context);
@@ -97,7 +87,7 @@ GMPy_Complex_Mul_2exp(PyObject *x, PyObject *y, CTXT_Object *context)
         /* LCOV_EXCL_STOP */
     }
 
-    if (is_negative) {
+    if (is_signed) {
         result->rc = mpc_mul_2si(result->c, tempx->c, exp,
                                  GET_MPC_ROUND(context));
     }
@@ -159,12 +149,13 @@ static PyObject *
 GMPy_Real_Div_2exp(PyObject *x, PyObject *y, CTXT_Object *context)
 {
     MPFR_Object *result, *tempx;
-    unsigned long exp = 0;
+    long exp;
+    int is_signed = 0;
 
     CHECK_CONTEXT(context);
 
-    exp = GMPy_Integer_AsUnsignedLong(y);
-    if (exp == (unsigned long)(-1) && PyErr_Occurred()) {
+    exp = GMPy_Integer_AsUnsignedLongOrLong(y, &is_signed);
+    if (exp == -1 && PyErr_Occurred()) {
         return NULL;
     }
 
@@ -180,7 +171,14 @@ GMPy_Real_Div_2exp(PyObject *x, PyObject *y, CTXT_Object *context)
 
     mpfr_clear_flags();
 
-    result->rc = mpfr_div_2ui(result->f, tempx->f, exp, GET_MPFR_ROUND(context));
+    if (is_signed) {
+        result->rc = mpfr_div_2si(result->f, tempx->f, exp,
+                                  GET_MPFR_ROUND(context));
+    }
+    else  {
+        result->rc = mpfr_div_2ui(result->f, tempx->f, exp,
+                                  GET_MPFR_ROUND(context));
+    }
     Py_DECREF((PyObject*)tempx);
     _GMPy_MPFR_Cleanup(&result, context);
     return (PyObject*)result;
@@ -190,12 +188,13 @@ static PyObject *
 GMPy_Complex_Div_2exp(PyObject *x, PyObject *y, CTXT_Object *context)
 {
     MPC_Object *result, *tempx;
-    unsigned long exp = 0;
+    long exp;
+    int is_signed = 0;
 
     CHECK_CONTEXT(context);
 
-    exp = GMPy_Integer_AsUnsignedLong(y);
-    if (exp == (unsigned long)(-1) && PyErr_Occurred()) {
+    exp = GMPy_Integer_AsUnsignedLongOrLong(y, &is_signed);
+    if (exp == -1 && PyErr_Occurred()) {
         return NULL;
     }
 
@@ -209,7 +208,14 @@ GMPy_Complex_Div_2exp(PyObject *x, PyObject *y, CTXT_Object *context)
         /* LCOV_EXCL_STOP */
     }
 
-    result->rc = mpc_div_2ui(result->c, tempx->c, exp, GET_MPC_ROUND(context));
+    if (is_signed) {
+        result->rc = mpc_div_2si(result->c, tempx->c, exp,
+                                 GET_MPC_ROUND(context));
+    }
+    else {
+        result->rc = mpc_div_2ui(result->c, tempx->c, exp,
+                                 GET_MPC_ROUND(context));
+    }
     Py_DECREF((PyObject*)tempx);
     _GMPy_MPC_Cleanup(&result, context);
     return (PyObject*)result;

--- a/src/gmpy2_muldiv_2exp.c
+++ b/src/gmpy2_muldiv_2exp.c
@@ -46,9 +46,11 @@ GMPy_Real_Mul_2exp(PyObject *x, PyObject *y, CTXT_Object *context)
     result = GMPy_MPFR_New(0, context);
     tempx = GMPy_MPFR_From_Real(x, 1, context);
     if (!result || !tempx) {
+        /* LCOV_EXCL_START */
         Py_XDECREF((PyObject*)result);
         Py_XDECREF((PyObject*)tempx);
         return NULL;
+        /* LCOV_EXCL_STOP */
     }
 
     mpfr_clear_flags();
@@ -88,9 +90,11 @@ GMPy_Complex_Mul_2exp(PyObject *x, PyObject *y, CTXT_Object *context)
     result = GMPy_MPC_New(0, 0, context);
     tempx = GMPy_MPC_From_Complex(x, 1, 1, context);
     if (!result || !tempx) {
+        /* LCOV_EXCL_START */
         Py_XDECREF((PyObject*)result);
         Py_XDECREF((PyObject*)tempx);
         return NULL;
+        /* LCOV_EXCL_STOP */
     }
 
     if (is_negative) {
@@ -167,9 +171,11 @@ GMPy_Real_Div_2exp(PyObject *x, PyObject *y, CTXT_Object *context)
     result = GMPy_MPFR_New(0, context);
     tempx = GMPy_MPFR_From_Real(x, 1, context);
     if (!result || !tempx) {
+        /* LCOV_EXCL_START */
         Py_XDECREF((PyObject*)result);
         Py_XDECREF((PyObject*)tempx);
         return NULL;
+        /* LCOV_EXCL_STOP */
     }
 
     mpfr_clear_flags();
@@ -196,9 +202,11 @@ GMPy_Complex_Div_2exp(PyObject *x, PyObject *y, CTXT_Object *context)
     result = GMPy_MPC_New(0, 0, context);
     tempx = GMPy_MPC_From_Complex(x, 1, 1, context);
     if (!result || !tempx) {
+        /* LCOV_EXCL_START */
         Py_XDECREF((PyObject*)result);
         Py_XDECREF((PyObject*)tempx);
         return NULL;
+        /* LCOV_EXCL_STOP */
     }
 
     result->rc = mpc_div_2ui(result->c, tempx->c, exp, GET_MPC_ROUND(context));
@@ -249,4 +257,3 @@ GMPy_Context_Div_2exp(PyObject *self, PyObject *args)
                                 PyTuple_GET_ITEM(args, 1),
                                 context);
 }
-

--- a/test/test_functions.py
+++ b/test/test_functions.py
@@ -1,3 +1,4 @@
+import ctypes
 from fractions import Fraction
 
 import pytest
@@ -1566,6 +1567,12 @@ def test_iroot():
                                    ((mpz(3), False), (mpz(4), False)),
                                    ((mpz(2), False), (mpz(3), False))]
     assert iroot(9,2) == (mpz(3), True)
+
+    ULONG_MAX = ctypes.c_ulong(-1).value
+
+    assert iroot(4,ULONG_MAX) == (mpz(1), False)
+
+    pytest.raises(OverflowError, lambda: iroot(4,ULONG_MAX+1))
 
 
 def test_iroot_rem():

--- a/test/test_generic.py
+++ b/test/test_generic.py
@@ -307,14 +307,20 @@ def test_muldiv_2exp():
     assert gmpy2.mul_2exp(r, z) == mpfr('60.799999999999997')
     assert gmpy2.mul_2exp(r, 3) == mpfr('60.799999999999997')
 
-    pytest.raises(OverflowError, lambda: gmpy2.mul_2exp(r, -5))
+    assert gmpy2.mul_2exp(r, -5) == mpfr('0.23749999999999999')
+    assert gmpy2.mul_2exp(1, -5) == mpfr('0.03125')  # issue 328
+
+    pytest.raises(OverflowError, lambda: gmpy2.mul_2exp(z, 10**100))
+    pytest.raises(OverflowError, lambda: gmpy2.mul_2exp(z, -10**100))
     pytest.raises(TypeError, lambda: gmpy2.mul_2exp(z, r))
     pytest.raises(TypeError, lambda: gmpy2.mul_2exp('not', 5))
     pytest.raises(TypeError, lambda: ctx.mul_2exp(r, z, 45))
 
     assert ctx.mul_2exp(c, z) == mpc('32.0+32.0j')
+    assert ctx.mul_2exp(c, -5) == mpc('0.125+0.125j')
 
-    pytest.raises(OverflowError, lambda: ctx.mul_2exp(c, -5))
+    pytest.raises(OverflowError, lambda: ctx.mul_2exp(c, 10**100))
+    pytest.raises(OverflowError, lambda: ctx.mul_2exp(c, -10**100))
 
     assert ctx.mul_2exp(r, 0) == mpfr('7.5999999999999996')
 

--- a/test/test_generic.py
+++ b/test/test_generic.py
@@ -326,12 +326,16 @@ def test_muldiv_2exp():
 
     assert gmpy2.div_2exp(r, z) == mpfr('0.94999999999999996')
     assert gmpy2.div_2exp(r, 3) == mpfr('0.94999999999999996')
+    assert gmpy2.div_2exp(r, -5) == mpfr('243.19999999999999')
 
-    pytest.raises(OverflowError, lambda: gmpy2.div_2exp(r, -5))
+    pytest.raises(OverflowError, lambda: gmpy2.div_2exp(r, 10**100))
+    pytest.raises(OverflowError, lambda: gmpy2.div_2exp(r, -10**100))
     pytest.raises(TypeError, lambda: gmpy2.div_2exp(z, r))
     pytest.raises(TypeError, lambda: gmpy2.div_2exp('not', 5))
     pytest.raises(TypeError, lambda: ctx.div_2exp(r, z, 45))
 
     assert ctx.div_2exp(c, z) == mpc('0.5+0.5j')
+    assert ctx.div_2exp(c, -5) == mpc('128.0+128.0j')
 
-    pytest.raises(OverflowError, lambda: ctx.div_2exp(c, -5))
+    pytest.raises(OverflowError, lambda: ctx.div_2exp(c, 10**100))
+    pytest.raises(OverflowError, lambda: ctx.div_2exp(c, -10**100))


### PR DESCRIPTION
* We try to convert to unsigned long (for mpfr_mul_2ui) and fallback to long on overflow (for mpfr_mul_2si), closes #328
* Add GMPy_Integer_AsUnsignedLongOrLong() and adapt div_2exp() like above
* Return OverflowError in iroot(x,n) iff n>ULONG_MAX, closes https://github.com/aleaxit/gmpy/issues/257