### PR TITLE
Fix CI on gmpy2-2.1.6 branch

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-latest]
+        os: [ubuntu-20.04, macos-12]
         python-version: ['3.7']
 
     steps:

--- a/.github/workflows/build_wheels_legacy.yml
+++ b/.github/workflows/build_wheels_legacy.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-10.15]
+        os: [ubuntu-20.04, macos-12]
         python-version: ["3.7"]
 
     steps:

--- a/.github/workflows/pip_install_gmpy2.yml
+++ b/.github/workflows/pip_install_gmpy2.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.7]
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-python@master
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.7]
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/pip_install_gmpy2.yml
+++ b/.github/workflows/pip_install_gmpy2.yml
@@ -1,23 +1,6 @@
 name: pip_install_gmpy2
-on:
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'test/**'
-      - 'test_cython/**'
-      - '**.py'
 
-  push:
-    branches:
-      - master
-    paths:
-      - 'src/**'
-      - 'test/**'
-      - 'test_cython/**'
-      - '**.py'
-      - '.github/workflows/**.yml'
+on: [push, pull_request]
 
 jobs:
   osx:

--- a/scripts/before_ci_build.sh
+++ b/scripts/before_ci_build.sh
@@ -6,7 +6,7 @@ if [ ! -f finish_before_ci_build ]; then
     if [[ "$OSTYPE" == "linux-gnu" ]]; then
       yum install -y xz
     fi
-    curl -O https://gmplib.org/download/gmp/gmp-${GMP_VERSION}.tar.xz
+    curl -O -k https://ftp.gnu.org/gnu/gmp/gmp-${GMP_VERSION}.tar.xz
     tar -xvf gmp-${GMP_VERSION}.tar.xz
     # need to set host to the oldest triple to avoid building binaries
     # that use build machine micro-architecure. configfsf.guess is the one that

--- a/scripts/before_ci_build_apple_silicon.sh
+++ b/scripts/before_ci_build_apple_silicon.sh
@@ -7,7 +7,7 @@ EXTRA="--build=x86_64-apple-darwin --host=aarch64-apple-darwin --target=aarch64-
 if [ ! -f finish_before_ci_build ]; then
   if [[ "$OSTYPE" == "linux-gnu" || "$OSTYPE" == "linux-musl" || "$OSTYPE" == "darwin"* ]]; then
     echo $PWD
-    curl -O https://gmplib.org/download/gmp/gmp-${GMP_VERSION}.tar.xz
+    curl -O -k https://ftp.gnu.org/gnu/gmp/gmp-${GMP_VERSION}.tar.xz
     tar -xf gmp-${GMP_VERSION}.tar.xz
     cd gmp-${GMP_VERSION}
     patch -N -Z -p0 < ../scripts/patch-arm64.diff

--- a/src/gmpy2_cache.c
+++ b/src/gmpy2_cache.c
@@ -537,19 +537,17 @@ GMPy_MPFR_New(mpfr_prec_t bits, CTXT_Object *context)
 
     if (global.in_gmpympfrcache) {
         result = global.gmpympfrcache[--(global.in_gmpympfrcache)];
-        /* Py_INCREF does not set the debugging pointers, so need to use
-           _Py_NewReference instead. */
-        _Py_NewReference((PyObject*)result);
-        mpfr_set_prec(result->f, bits);
+        Py_INCREF((PyObject*)result);
     }
     else {
-        if (!(result = PyObject_New(MPFR_Object, &MPFR_Type))) {
+        result = PyObject_New(MPFR_Object, &MPFR_Type);
+        if (result == NULL) {
             /* LCOV_EXCL_START */
             return NULL;
             /* LCOV_EXCL_STOP */
         }
-        mpfr_init2(result->f, bits);
     }
+    mpfr_init2(result->f, bits);
     result->hash_cache = -1;
     result->rc = 0;
     return result;
@@ -704,7 +702,7 @@ set_gmpympccache(void)
 static MPC_Object *
 GMPy_MPC_New(mpfr_prec_t rprec, mpfr_prec_t iprec, CTXT_Object *context)
 {
-    MPC_Object *self;
+    MPC_Object *result;
 
     if (rprec < 2) {
         CHECK_CONTEXT(context);
@@ -722,29 +720,21 @@ GMPy_MPC_New(mpfr_prec_t rprec, mpfr_prec_t iprec, CTXT_Object *context)
         return NULL;
     }
     if (global.in_gmpympccache) {
-        self = global.gmpympccache[--(global.in_gmpympccache)];
-        /* Py_INCREF does not set the debugging pointers, so need to use
-           _Py_NewReference instead. */
-        _Py_NewReference((PyObject*)self);
-        if (rprec == iprec) {
-            mpc_set_prec(self->c, rprec);
-        }
-        else {
-            mpc_clear(self->c);
-            mpc_init3(self->c, rprec, iprec);
-        }
+        result = global.gmpympccache[--(global.in_gmpympccache)];
+        Py_INCREF((PyObject*)result);
     }
     else {
-        if (!(self = PyObject_New(MPC_Object, &MPC_Type))) {
+        result = PyObject_New(MPC_Object, &MPC_Type);
+        if (result == NULL) {
             /* LCOV_EXCL_START */
             return NULL;
             /* LCOV_EXCL_STOP */
         }
-        mpc_init3(self->c, rprec, iprec);
     }
-    self->hash_cache = -1;
-    self->rc = 0;
-    return self;
+    mpc_init3(result->c, rprec, iprec);
+    result->hash_cache = -1;
+    result->rc = 0;
+    return result;
 }
 
 static PyObject *

--- a/src/gmpy2_format.c
+++ b/src/gmpy2_format.c
@@ -592,12 +592,14 @@ GMPy_MPC_Format(PyObject *self, PyObject *args)
     if (mpcstyle)
         strcat(tempbuf, " ");
     else {
+#if MPFR_VERSION < MPFR_VERSION_NUM(4,2,1)
         /* Need to insert + if imag is nan or +inf. */
         if (mpfr_nan_p(mpc_imagref(MPC(self))) ||
             (mpfr_inf_p(mpc_imagref(MPC(self))) &&
              mpfr_sgn(mpc_imagref(MPC(self))) > 0)) {
             strcat(tempbuf, "+");
         }
+#endif
     }
     strcat(tempbuf, imagbuf);
     if (strlen(imagbuf) < 50 &&


### PR DESCRIPTION
28c81b8 Update versions for runners in CI
af43dc6 Enable pip_install_gmpy2.yml for push/pr (it's cheap!)
fec75d2 Use ftp.gnu.org for GMP download
c57464b Exclude MPFR workaround for MPFR >= 4.2.1
4cecd73 Additional patch from aleaxit/gmpy#418
