### PR TITLE
Use codecov-action v4

### DIFF
--- a/.github/workflows/pip_install_gmpy2.yml
+++ b/.github/workflows/pip_install_gmpy2.yml
@@ -64,11 +64,13 @@ jobs:
           lcov --capture --directory . --no-external --output-file build/coverage.info
           genhtml build/coverage.info --output-directory build/coverage
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           gcov: true
           gcov_include: src/*.c
           gcov_args: --no-external
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Archive build artifacts
         uses: actions/upload-artifact@v4
         if: matrix.python-version == 3.11


### PR DESCRIPTION
It seems, https://app.codecov.io/gh/aleaxit/gmpy - not updating. And coverage for new pull requests is missing too:
https://app.codecov.io/gh/aleaxit/gmpy/pulls?prStates%5B0%5D=OPEN

This update codecov-action version and add fail_ci_if_error option to prevent CI failures on the master.  In this form, submitting data works in mpmath's prs.

If someone menages to add CODECOV_TOKEN (as it's explained in https://github.com/codecov/codecov-action/?tab=readme-ov-file#usage)
- then we could remove fail_ci_if_error option (defaults to true).