### PR TITLE
Use int instead of char for flag variables

### DIFF
--- a/src/gmpy2_convert.c
+++ b/src/gmpy2_convert.c
@@ -178,7 +178,8 @@ GMPy_RemoveIgnoredASCII(PyObject *s)
 static int
 mpz_set_PyStr(mpz_t z, PyObject *s, int base)
 {
-    char *cp, negative = 0;
+    char *cp;
+    int negative = 0;
     PyObject *ascii_str;
 
     ascii_str = GMPy_RemoveIgnoredASCII(s);

--- a/src/gmpy2_mpz_misc.c
+++ b/src/gmpy2_mpz_misc.c
@@ -1869,8 +1869,8 @@ GMPy_MPZ_Method_To_Bytes(PyObject *self, PyObject *const *args,
     Py_ssize_t i, nkws = 0, size, gap, length = 1;
     PyObject *bytes, *arg;
     mpz_t tmp, *px = &MPZ(self);
-    char *buffer, sign, is_signed = 0, is_negative, is_big;
-    int argidx[2] = {-1, -1};
+    char *buffer;
+    int sign, is_signed = 0, is_negative, is_big, argidx[2] = {-1, -1};
     const char *byteorder = NULL, *kwname;
 
     if (nargs > 2) {
@@ -2023,8 +2023,8 @@ GMPy_MPZ_Method_From_Bytes(PyTypeObject *type, PyObject *const *args, Py_ssize_t
 {
     Py_ssize_t i, nkws = 0, length;
     PyObject *arg, *bytes;
-    char is_signed = 0, endian, *buffer;
-    int argidx[2] = {-1, -1};
+    char *buffer;
+    int is_signed = 0, endian, argidx[2] = {-1, -1};
     const char *byteorder = NULL, *kwname;
     mpz_t tmp;
     MPZ_Object *result;


### PR DESCRIPTION
I attempted to build version 2.2.0 for Fedora Rawhide.  All of the non-x86 architectures (aarch, ppc64le, and s390x) failed a test:
```
=================================== FAILURES ===================================
_____________________________ test_mpz_from_bytes ______________________________

    @settings(max_examples=1000)
>   @given(integers(), integers(min_value=0, max_value=10000),
           sampled_from(['big', 'little']), booleans())

test/test_mpz.py:108: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/lib/python3.13/site-packages/hypothesis/core.py:1300: in _raise_to_user
    raise the_error_hypothesis_found
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

x = -2, length = 5, byteorder = 'little', signed = True

    @settings(max_examples=1000)
    @given(integers(), integers(min_value=0, max_value=10000),
           sampled_from(['big', 'little']), booleans())
    @example(0, 0, 'big', False)
    @example(0, 0, 'little', False)
    @example(0, 1, 'big', False)
    @example(128, 1, 'big', True)
    @example(128, 1, 'little', True)
    @example(-129, 1, 'big', True)
    @example(-129, 1, 'little', True)
    @example(-1, 0, 'big', True)
    @example(-1, 1, 'big', True)
    @example(-1, 1, 'little', True)
    @example(-2, 0, 'big', True)
    @example(-2, 0, 'little', True)
    @example(-1, 3, 'big', True)
    @example(-2, 3, 'big', True)
    @example(-2, 5, 'little', True)
    def test_mpz_from_bytes(x, length, byteorder, signed):
        try:
            bytes = x.to_bytes(length, byteorder, signed=signed)
        except OverflowError:
            assume(False)
        else:
            rx = int.from_bytes(bytes, byteorder, signed=signed)
>           assert rx == mpz.from_bytes(bytes, byteorder, signed=signed)
E           AssertionError: assert -2 == mpz(-4294967297)
E            +  where mpz(-4294967297) = <built-in method from_bytes of type object at 0xffffa57105b0>(b'\xfe\xff\xff\xff\xff', 'little', signed=True)
E            +    where <built-in method from_bytes of type object at 0xffffa57105b0> = mpz.from_bytes
E           Falsifying explicit example: test_mpz_from_bytes(
E               x=-2,
E               length=5,
E               byteorder='little',
E               signed=True,
E           )

test/test_mpz.py:132: AssertionError
```

The problem is the use of the `char` type for flag variables.  The C standard says that `char` can be equivalent to either `signed char` or `unsigned char`.  The code in `GMPy_MPZ_Method_From_Bytes` assigns -1 to such a variable, `endian`.  On platforms where `char` == `unsigned char`, the value stored is actually 255, a positive value.

This PR converts flag variables declared with type `char` to type `int` instead, for the following reasons:

1. Using `char` doesn't save any space.  These are local variables, so they are either in a CPU register (which is 32 or 64 bits, even if we only use 8 bits), or on the stack where, for alignment reasons, 32 bits will be reserved even though we only use 8 bits of it.
2. Using `char` instead of `int` generates less efficient code.  Modern 64-bit processors are optimized for processing 64-bit and 32-bit quantities.  They can operate on 8-bit quantities, but take more clock cycles to do so.
3. The `char` type is only useful for unsigned 7-bit values; i.e., 0 to 127.  That is the intersection of the `signed char` and `unsigned char` types.

With this change, the build succeeds on all architectures.