### PR TITLE
Misc fixes

### DIFF
--- a/docs/contexts.rst
+++ b/docs/contexts.rst
@@ -11,7 +11,7 @@ that contexts are mutable: modifying the reference returned by `get_context()`
 will modify the active context until a new context is enabled with
 `set_context()`.  The `context.copy()` method will return a copy of the
 context.  Contexts that implement the standard *single*, *double*, and
-*quadruple* precision floating point types can be created using `ieee()`.
+*quadruple* precision floating-point types can be created using `ieee()`.
 
 Context Type
 ------------

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -196,7 +196,7 @@ Changes in gmpy2 2.1.0a1
 * Context methods have been added for MPFR/MPC related functions.
 * A new context option (`~context.rational_division`) has been added that
   changes the behavior of integer division involving `mpz` instances to return
-  a rational result instead of a floating point result.
+  a rational result instead of a floating-point result.
 * gmpy2 types are now registered in the numeric tower of the
   :mod:`numbers` module.
 * In previous versions of gmpy2, ``mpz()`` was a factory function that

--- a/src/gmpy2_context.c
+++ b/src/gmpy2_context.c
@@ -195,7 +195,7 @@ GMPy_CTXT_Exit(PyObject *self, PyObject *args)
 
 PyDoc_STRVAR(GMPy_doc_context_ieee,
 "ieee(size, /, subnormalize=True) -> context\n\n"
-"Return a new context corresponding to a standard IEEE floating point\n"
+"Return a new context corresponding to a standard IEEE floating-point\n"
 "format. The supported sizes are 16, 32, 64, 128, and multiples of\n"
 "32 greater than 128.");
 
@@ -706,10 +706,10 @@ GETSET_BOOLEAN(rational_division)
 GETSET_BOOLEAN(allow_release_gil)
 
 PyDoc_STRVAR(GMPy_doc_CTXT_subnormalize,
-"The usual IEEE-754 floating point representation supports gradual\n"
+"The usual IEEE-754 floating-point representation supports gradual\n"
 "underflow when the minimum exponent is reached.  The MFPR library\n"
 "does not enable gradual underflow by default but it can be enabled\n"
-"to precisely mimic the results of IEEE-754 floating point operations.");
+"to precisely mimic the results of IEEE-754 floating-point operations.");
 
 PyDoc_STRVAR(GMPy_doc_CTXT_trap_underflow,
 "If set to `False`, a result that is smaller than the smallest possible\n"

--- a/src/gmpy2_convert_mpfr.c
+++ b/src/gmpy2_convert_mpfr.c
@@ -41,7 +41,7 @@
  * If bits (or prec) is set to 1, the precision of the result depends on the
  * type of the source.
  *
- *   If the source number is already a radix-2 floating point number,
+ *   If the source number is already a radix-2 floating-point number,
  *   the precision is not changed. In practical terms, this only applies
  *   to sources operands that are either an mpfr or Python double.
  *

--- a/src/gmpy2_macros.h
+++ b/src/gmpy2_macros.h
@@ -332,7 +332,9 @@ GMPy_RealWithType_##NAME(PyObject *x, int xtype, CTXT_Object *context) \
     result->rc = mpfr_##FUNC(result->f, tempx->f); \
     Py_DECREF((PyObject*)tempx); \
     _GMPy_MPFR_Cleanup(&result, context); \
-    return (PyObject*)result; \
+    MPZ_Object *mpz_result = GMPy_MPZ_From_MPFR(result, context); \
+    Py_DECREF((PyObject*)result); \
+    return (PyObject*)mpz_result; \
 } \
 static PyObject * \
 GMPy_Number_##NAME(PyObject *x, CTXT_Object *context) \

--- a/src/gmpy2_mpfr.c
+++ b/src/gmpy2_mpfr.c
@@ -117,7 +117,7 @@ PyDoc_STRVAR(GMPy_doc_mpfr,
 "the specified context or the current context is used.\n"
 "A precision of 1 minimizes the loss of precision by following\n"
 "these rules:\n\n"
-"    1) If n is a radix-2 floating point number, then the full\n"
+"    1) If n is a radix-2 floating-point number, then the full\n"
 "       precision of n is retained.\n"
 "    2) If n is an integer, then the precision is the bit length\n"
 "       of the integer.\n");

--- a/src/gmpy2_mpmath.c
+++ b/src/gmpy2_mpmath.c
@@ -287,14 +287,17 @@ Pympz_mpmath_create_fast(PyObject *self, PyObject *const *args, Py_ssize_t nargs
     switch (nargs) {
         case 4:
             rnd = PyString_1Char(args[3]);
+            /* fallthrough */
         case 3:
             prec = GMPy_Integer_AsLong(args[2]);
             if (prec == (mp_bitcnt_t)(-1)) {
                 VALUE_ERROR("could not convert prec to positive int");
                 return NULL;
             }
+            /* fallthrough */
         case 2:
             exp = args[1];
+            /* fallthrough */
         case 1:
             man = GMPy_MPZ_From_Integer(args[0], NULL);
             if (!man) {

--- a/test/test_mpfr.py
+++ b/test/test_mpfr.py
@@ -872,3 +872,30 @@ def test_mpfr_pickle():
     assert pickle.loads(pickle.dumps(mpfr("-inf"))) == mpfr('-inf')
     assert is_nan(pickle.loads(pickle.dumps(mpfr("nan"))))
     assert pickle.loads(pickle.dumps(mpfr(0))) == mpfr('0.0')
+
+
+def test_mpfr_floor():
+    a = mpfr('12.34')
+
+    ctx = get_context()
+    r = ctx.floor(a)
+
+    assert r == mpz(12) and isinstance(r, mpz)
+
+
+def test_mpfr_ceil():
+    a = mpfr('12.34')
+
+    ctx = get_context()
+    r = ctx.ceil(a)
+
+    assert r == mpz(13) and isinstance(r, mpz)
+
+
+def test_mpfr_trunc():
+    a = mpfr('12.34')
+
+    ctx = get_context()
+    r = ctx.trunc(a)
+
+    assert r == mpz(12) and isinstance(r, mpz)

--- a/test/test_mpfr.py
+++ b/test/test_mpfr.py
@@ -6,7 +6,7 @@ from fractions import Fraction
 
 import pytest
 from hypothesis import example, given, settings
-from hypothesis.strategies import floats
+from hypothesis.strategies import floats, integers
 from supportclasses import a, b, c, d, q, r, z
 
 import gmpy2
@@ -899,3 +899,11 @@ def test_mpfr_trunc():
     r = ctx.trunc(a)
 
     assert r == mpz(12) and isinstance(r, mpz)
+
+
+@given(floats(allow_nan=False, allow_infinity=False),
+       integers(-10, 40))
+def test_mpfr_round_roundtrip_bulk(x, n):
+    q = mpq(*x.as_integer_ratio())
+    assert float(round(q, n)) == round(x, n)
+    assert mpfr(round(q, n)) == round(mpfr(x), n)

--- a/test/test_mpq.py
+++ b/test/test_mpq.py
@@ -38,6 +38,10 @@ def test_mpq_from_float():
     assert mpq.from_float(3.2) == mpq(3602879701896397, 1125899906842624)
 
 
+def test_mpq_float():
+    assert float(mpq(9, 5)) == 1.8
+
+
 def test_mpq_from_Decimal():
     assert mpq(Decimal("5e-3")) == mpq(5, 1000)
     assert mpq(Decimal(1)) == mpq(1)  # issue 327


### PR DESCRIPTION
* consistently use "floating-point"
* correct return type for ``mpfr.__floor__``, ``__ceil__`` and ``__trunc__``, closes #143
* correct ``mpq.__float__()``, closes #498
* mark fallthroughs, closes #501

I'll mark also additional issues (merging this will close them too):
* closes #462
* closes #446
* closes #419
* closes #418
* closes #168
* closes #163
* closes #116
* closes #111
* closes #73
* closes #21
* closes #451