### PR TITLE
Fix manpage typos

### DIFF
--- a/src/gmpy2_context.c
+++ b/src/gmpy2_context.c
@@ -536,7 +536,7 @@ PyDoc_STRVAR(GMPy_doc_local_context,
 "local_context(context, /, **kwargs) -> context\n\n"
 "Return a new context for controlling gmpy2 arithmetic, based either\n"
 "on the current context or on a ctx value.  Context options additionally\n"
-"can be overriden by keyword arguments.");
+"can be overridden by keyword arguments.");
 
 static PyObject *
 GMPy_CTXT_Local(PyObject *self, PyObject *args, PyObject *kwargs)
@@ -591,7 +591,7 @@ PyDoc_STRVAR(GMPy_doc_context,
 "context(ctx, /, **kwargs)\n\n"
 "Return a new context for controlling gmpy2 arithmetic, based either\n"
 "on the default context or on a given by ctx value.  Context options\n"
-"additionally can be overriden by keyword arguments.");
+"additionally can be overridden by keyword arguments.");
 
 static PyObject *
 GMPy_CTXT_Context(PyTypeObject *type, PyObject *args, PyObject *kwargs)


### PR DESCRIPTION
Simple manpage typos found by Lintian as part of the Debian packaging process.