### PR TITLE
Misc fixes

### DIFF
--- a/src/gmpy2.c
+++ b/src/gmpy2.c
@@ -579,7 +579,7 @@ gmp_abort_handler(int i)
             printf("gmp: root of negative\n");
         }
         else {
-            printf("gmp: out of memory\n");
+            printf("gmp: overflow in mpz type\n");
         }
     }
     abort();

--- a/test/test_mpz.py
+++ b/test/test_mpz.py
@@ -442,11 +442,14 @@ def test_mpz_create():
     assert mpz(' 1 2') == mpz(12)
 
 
+@settings(max_examples=10000)
 @given(integers())
 @example(0)
 @example(-3)
 def test_mpz_conversion_bulk(n):
-    assert int(mpz(n)) == n
+    m = mpz(n)
+    assert int(m) == n
+    assert str(m) == str(n)
 
 
 @settings(max_examples=1000)


### PR DESCRIPTION
* more samples + test str(int)==str(mpz) in test_mpz_conversion_bulk()
* more correct error message for MPZ_OVERFLOW error in GMP