### PR TITLE
Remove invalid cast in _get_ieee_context

### DIFF
--- a/src/gmpy2_convert_gmp.c
+++ b/src/gmpy2_convert_gmp.c
@@ -197,7 +197,7 @@ _get_ieee_context(long bitwidth)
     }
     result->ctx.subnormalize = 1;
     result->ctx.emin = 4 - result->ctx.emax - result->ctx.mpfr_prec;
-    return (PyObject*)result;
+    return result;
 }
 
 static PyObject *


### PR DESCRIPTION
This fixes the following build failure:

```
  gcc [...] -I/usr/include/python3.12 -c src/gmpy2.c -o build/temp.linux-x86_64-cpython-312/src/gmpy2.o -DSHARED=1
  In file included from src/gmpy2.c:201:
  src/gmpy2_convert_gmp.c: In function ‘_get_ieee_context’:
  src/gmpy2_convert_gmp.c:200:12: error: returning ‘PyObject *’ {aka ‘struct _object *’} from a function with incompatible return type ‘CTXT_Object *’ [-Wincompatible-pointer-types]
    200 |     return (PyObject*)result;
```