### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Supported Versions
+
+Below are the versions of gmpy2 currently supported with security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 2.1.x   | :white_check_mark: |
+| 2.0.x   | :x:                |
+| < 2.0   | :x:                |
+
+## Reporting a Vulnerability
+
+To report a vulnerability, please email [maintainer-email@example.com] or open an issue on GitHub (preferably marked as private if sensitive). We’ll aim to respond within 5 business days. If the vulnerability is accepted, we’ll work on a fix and coordinate disclosure; if declined, we’ll provide reasoning. For urgent issues, please indicate priority in your report.


### PR DESCRIPTION
I don't know active maintainer's email, so just placed a placeholder. 

This library is being used by guys like me for building cryptolibs and only recently I've read this:

> gmpy2 can crash the Python interpreter in case of memory allocation failure. To mitigate this feature of memory management in the GMP library, you should estimate the size of all results and prevent calculations that can exaust available memory.

If I haven't gone for info about how C part of gmpy2 was compiled, I would have missed this vulnerability. The gmpy2 should have a Security policy and a proper vulnerability reporting and disclosing mechanism to prevent this.