### PR TITLE
Correct optimization for negative ndigits in mpz.__round__()

### DIFF
--- a/src/gmpy2_mpz_misc.c
+++ b/src/gmpy2_mpz_misc.c
@@ -267,7 +267,7 @@ GMPy_MPZ_Method_Round(PyObject *self, PyObject *const *args,
     round_digits = -round_digits;
 
     if ((result = GMPy_MPZ_New(NULL))) {
-        if ((unsigned)round_digits >= mpz_sizeinbase(MPZ(self), 10)) {
+        if ((unsigned)round_digits > mpz_sizeinbase(MPZ(self), 10)) {
             mpz_set_ui(result->z, 0);
         }
         else {

--- a/test/test_mpz.py
+++ b/test/test_mpz.py
@@ -508,6 +508,9 @@ def test_mpz_round():
     raises(TypeError, lambda: round(mpz(123456),'a'))
     raises(TypeError, lambda: round(mpz(123456),'a',4))
 
+    # issue 552
+    assert round(mpz(501), -3) == mpz(1000)
+
 
 @settings(max_examples=10000)
 @given(integers())


### PR DESCRIPTION
The GNU GMP manual says that about mpz_sizeinbaze(): "The result will be either exact or 1 too big."  First happened for example in the issue. We should use strict inequality to handle this.

Closes #552