### PR TITLE
Fix test_mpfr_mpmath for different exception in mpmath 1.4.0a5

### DIFF
--- a/test/test_mpfr.py
+++ b/test/test_mpfr.py
@@ -311,7 +311,7 @@ def test_mpfr_mpmath():
     assert mpfr(d)._mpf_ == (0, mpz(0), 1, 1)
     pytest.raises(TypeError, lambda: gmpy2._mpmath_create(1))
     pytest.raises(ValueError, lambda: gmpy2._mpmath_create(1, 1, -1))
-    pytest.raises(TypeError, lambda: mpmath.mpf(("!", 1,)))
+    pytest.raises((TypeError, ValueError), lambda: mpmath.mpf(("!", 1,)))
 
 
 def test_mpfr_format():


### PR DESCRIPTION
Update the assertion in `test_mpfr_mpmath()` to accept both `TypeError` as emitted by mpmath 1.3.0, and `ValueError` as emitted by mpmath 1.4.0a5:

```
>               v._mpf_ = from_man_exp(MPZ(val[0]), val[1], prec, rounding)
                                       ^^^^^^^^^^^
E               ValueError: invalid digits
```