### PR TITLE
Advertise python-gmp ;-)

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -11,7 +11,7 @@ jobs:
         os: [ubuntu-22.04, ubuntu-24.04-arm, macos-13, macos-14, macos-15, windows-2022]
     steps:
       - uses: actions/checkout@v4
-      - uses: msys2/setup-msys2@v2
+      - uses: msys2/setup-msys2@v2.27.0
         name: Setup msys2
         with:
           install: >-

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -14,7 +14,9 @@ values.   The cutover point for performance varies, but can be as low as 20 to
     gmpy2 can crash the Python interpreter in case of memory allocation
     failure.  To mitigate this feature of memory management in the GMP library,
     you should estimate the size of all results and prevent calculations that
-    can exaust available memory.
+    can exaust available memory.  In case you are interested only in
+    the GMP bindings, you can use the
+    `python-gmp <https://pypi.org/project/python-gmp/>`_ package.
 
 The `mpfr` and `mpc` types provide support for correctly rounded multiple
 precision real and complex arithmetic via the MPFR and MPC libraries.  The


### PR DESCRIPTION
closes #529

I'll mark also additional issues (merging this will close them too):

  * closes #132 - support for ancient MPFR/MPC
  * closes #518 - use abs() in cython
  * closes #472 - using gmpy2 C-API
  * closes #340 - crash with cached_context (not used anymore)
  * closes #128 - compile error for anciend gmpy2-2.0.8 on py2
  * closes #102 - compiling ancient 2.0.7 on Windows
  * closes #16 - use cython for wrapping.  Nope ;-)
  * closes #22 - _mpmath_mpf_mul patch (not accessible)
  * closes #95 - setup.py --prefix
  * closes #119 - tagging releases
  * closes #122 - support for ``__new__``
  * closes #146 - release?
  * closes #158 - tests with MPIR (not supported)
  * closes #176 - refactor build processes (now it much different)
  * closes #185 - setuptools issue
  * closes #199 - 2.1.0 Beta
  * closes #488 - 2.2.0: change in tagging convention?
  * closes #384 - pycharm issue with multiple signatures for mpz