### PR TITLE
Implement basic support for the free-threaded build

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.23.0
         env:
-          CIBW_ENABLE: pypy cpython-prerelease
+          CIBW_ENABLE: pypy cpython-prerelease cpython-freethreading
           CIBW_SKIP: pp38* pp39* *-win32 *-manylinux_armv7l
           CIBW_BEFORE_ALL: bash scripts/cibw_before_all.sh
           CIBW_BEFORE_ALL_WINDOWS: msys2 -c scripts/cibw_before_all.sh

--- a/.github/workflows/pip_install_gmpy2.yml
+++ b/.github/workflows/pip_install_gmpy2.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9, 3.11, pypy3.10, pypy3.11, 3.14]
+        python-version: [3.9, 3.11, pypy3.10, pypy3.11, 3.13, 3.13t, 3.14]
         os: [ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     steps:

--- a/scripts/cibw_before_all.sh
+++ b/scripts/cibw_before_all.sh
@@ -15,6 +15,10 @@ cd gmp-${GMP_VERSION}
 # Patch the mp_bitcnt_t to "unsigned long long int" on WINDOWS AMD64:
 patch -N -Z -p0 < ../scripts/mp_bitcnt_t.diff
 patch -N -Z -p0 < ../scripts/fat_build_fix.diff
+if [ "$OSTYPE" = "msys" ] || [ "$OSTYPE" = "cygwin" ]
+then
+  patch -N -Z -p0 < ../scripts/dll-importexport.diff
+fi
 # config.guess uses microarchitecture and configfsf.guess doesn't
 # We replace config.guess with configfsf.guess to avoid microarchitecture
 # specific code in common code.

--- a/scripts/dll-importexport.diff
+++ b/scripts/dll-importexport.diff
@@ -1,0 +1,13 @@
+--- gmp-h.in.orig	2025-06-28 12:29:00.346848835 +0300
++++ gmp-h.in	2025-06-28 12:29:37.324340854 +0300
+@@ -101,8 +101,8 @@
+    make use of that.  Probably more trouble than it's worth.  */
+
+ #if defined (__GNUC__)
+-#define __GMP_DECLSPEC_EXPORT  __declspec(__dllexport__)
+-#define __GMP_DECLSPEC_IMPORT  __declspec(__dllimport__)
++#define __GMP_DECLSPEC_EXPORT
++#define __GMP_DECLSPEC_IMPORT
+ #endif
+ #if defined (_MSC_VER) || defined (__BORLANDC__)
+ #define __GMP_DECLSPEC_EXPORT  __declspec(dllexport)

--- a/src/gmpy2.c
+++ b/src/gmpy2.c
@@ -127,8 +127,6 @@ LGPL 3 or later.";
 #define MAX_CACHE_MPFR_BITS (1024)
 
 typedef struct {
-    mpz_t tempz;             /* Temporary variable used for integer conversions */
-
     MPZ_Object *gmpympzcache[CACHE_SIZE+1];
     int in_gmpympzcache;
 

--- a/src/gmpy2.c
+++ b/src/gmpy2.c
@@ -118,7 +118,7 @@ LGPL 3 or later.";
 /* The following global structures are used by gmpy_cache.c.
  */
 
-#ifndef PYPY_VERSION
+#if !defined(PYPY_VERSION) && !Py_GIL_DISABLED
 #define CACHE_SIZE (100)
 #else
 #define CACHE_SIZE (0)
@@ -961,7 +961,7 @@ static PyModuleDef_Slot Pygmpy_slots[] = {
      Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED},
 #  endif
 #  if PY_VERSION_HEX >= 0x030D0000
-    {Py_mod_gil, Py_MOD_GIL_USED},
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
 #  endif
     {0, NULL}
 };

--- a/src/gmpy2.c
+++ b/src/gmpy2.c
@@ -118,7 +118,7 @@ LGPL 3 or later.";
 /* The following global structures are used by gmpy_cache.c.
  */
 
-#if !defined(PYPY_VERSION) && !Py_GIL_DISABLED
+#if !defined(PYPY_VERSION) && !defined(Py_GIL_DISABLED)
 #define CACHE_SIZE (100)
 #else
 #define CACHE_SIZE (0)
@@ -167,17 +167,6 @@ static PyObject *GMPyExc_Invalid = NULL;
 static PyObject *GMPyExc_Overflow = NULL;
 static PyObject *GMPyExc_Underflow = NULL;
 static PyObject *GMPyExc_Erange = NULL;
-
-#ifndef PYPY_VERSION
-/*
- * Parameters of Python’s internal representation of integers.
- */
-
-
-size_t int_digit_size, int_nails, int_bits_per_digit;
-int int_digits_order, int_endianness;
-#endif
-
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  * End of global data declarations.                                        *
@@ -579,17 +568,6 @@ gmpy_exec(PyObject *gmpy_module)
     PyObject *numbers_module = NULL;
     PyObject* xmpz = NULL;
     PyObject* limb_size = NULL;
-
-#ifndef PYPY_VERSION
-    /* Query parameters of Python’s internal representation of integers. */
-    const PyLongLayout *layout = PyLong_GetNativeLayout();
-
-    int_digit_size = layout->digit_size;
-    int_digits_order = layout->digits_order;
-    int_bits_per_digit = layout->bits_per_digit;
-    int_nails = int_digit_size*8 - int_bits_per_digit;
-    int_endianness = layout->digit_endianness;
-#endif
 
 #ifndef STATIC
     static void *GMPy_C_API[GMPy_API_pointers];


### PR DESCRIPTION
* skip cache for them
* test in CI
* build wheels
* remove global cache for int's layout

See https://github.com/aleaxit/gmpy/issues/584