### PR TITLE
Drop support for CPython 3.9

### DIFF
--- a/.github/workflows/pip_install_gmpy2.yml
+++ b/.github/workflows/pip_install_gmpy2.yml
@@ -29,8 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9, 3.11, pypy3.11, 3.12, 3.13, 3.13t,
-                         3.14, 3.14t]
+        python-version: ['3.10', 3.11, pypy3.11, 3.12, 3.13, 3.13t, 3.14, 3.14t]
         os: [ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     steps:

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,14 +1,14 @@
 Installation
 ============
 
-gmpy2 requires CPython 3.9 or above.  Pre-compiled binary wheels are available
+gmpy2 requires CPython 3.10 or above.  Pre-compiled binary wheels are available
 on PyPI.  You can install latest release with pip::
 
     pip install gmpy2
 
 or some specific version with::
 
-    pip install gmpy2==2.1.5
+    pip install gmpy2==2.2.2
 
 
 From Sources

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = ['Development Status :: 5 - Production/Stable',
                'Operating System :: POSIX',
                'Programming Language :: C',
                'Programming Language :: Python :: 3',
-               'Programming Language :: Python :: 3.9',
                'Programming Language :: Python :: 3.10',
                'Programming Language :: Python :: 3.11',
                'Programming Language :: Python :: 3.12',
@@ -33,7 +32,7 @@ classifiers = ['Development Status :: 5 - Production/Stable',
                "Programming Language :: Python :: Implementation :: PyPy",
                'Topic :: Scientific/Engineering :: Mathematics',
                'Topic :: Software Development :: Libraries :: Python Modules']
-requires-python = '>=3.9'
+requires-python = '>=3.10'
 
 [project.readme]
 file = 'README.rst'
@@ -42,7 +41,7 @@ content-type = 'text/x-rst'
 [project.optional-dependencies]
 docs = ['sphinx>=4', 'sphinx-rtd-theme>=1']
 tests = ['pytest', 'hypothesis', 'cython', 'mpmath', 'setuptools',
-         'numpy; python_version>="3.10" and platform_system=="Linux" and platform_python_implementation!="PyPy"']
+         'numpy; platform_system=="Linux" and platform_python_implementation!="PyPy"']
 
 [project.urls]
 Homepage = 'https://github.com/gmpy2/gmpy2'

--- a/src/gmpy2.h
+++ b/src/gmpy2.h
@@ -67,8 +67,8 @@ extern "C" {
 
 /* Check for minimum Python version requirements. */
 
-#if PY_VERSION_HEX < 0x03090000
-#  error "GMPY2 requires Python 3.9 or later."
+#if PY_VERSION_HEX < 0x030A0000
+#  error "GMPY2 requires Python 3.10 or later."
 #endif
 
 /* Include headers for GMP, MPFR, and MPC. */

--- a/src/gmpy2_hash.c
+++ b/src/gmpy2_hash.c
@@ -114,11 +114,7 @@ _mpfr_hash(mpfr_t f)
             }
         }
         else {
-#if PY_VERSION_HEX >= 0x030A00A0
             return Py_HashPointer(f);
-#else
-            return _PyHASH_NAN;
-#endif
         }
     }
 


### PR DESCRIPTION
N.B. here we get rid of just one workaround for pre-3.10 versions.  So, I don't think this has much sense for 2.3.0.