### PR TITLE
Misc fixes

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -34,7 +34,7 @@ jobs:
           path-type: inherit
         if: contains(matrix.os, 'windows')
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.4.1
+        uses: pypa/cibuildwheel@v4.1.0
       - uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.os }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = ['Development Status :: 5 - Production/Stable',
                'Programming Language :: Python :: 3.12',
                'Programming Language :: Python :: 3.13',
                'Programming Language :: Python :: 3.14',
+               'Programming Language :: Python :: 3.15',
                'Programming Language :: Python :: Free Threading :: 2 - Beta',
                'Programming Language :: Python :: Implementation :: CPython',
                "Programming Language :: Python :: Implementation :: PyPy",
@@ -39,7 +40,8 @@ content-type = 'text/x-rst'
 
 [project.optional-dependencies]
 docs = ['sphinx>=4', 'sphinx-rtd-theme>=1']
-tests = ['pytest', 'hypothesis', 'cython', 'mpmath', 'setuptools', 'numpy']
+tests = ['pytest', 'hypothesis', 'cython', 'mpmath', 'setuptools',
+         'numpy; python_version<"3.15"']
 
 [project.urls]
 Homepage = 'https://github.com/gmpy2/gmpy2'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ xfail_strict = true
 
 [tool.cibuildwheel]
 build-frontend = {name="build", args=["--verbose"]}
-enable = "pypy cpython-prerelease cpython-freethreading"
+enable = "pypy cpython-prerelease"
 before-all = "bash scripts/cibw_before_all.sh"
 test-extras = "tests"
 test-command = """pytest {package}/test && \

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,6 @@ else:
 class Gmpy2Build(build_ext):
     description = "Build gmpy2 with custom build options"
     user_options = build_ext.user_options + [
-        ('fast', None,
-         "Depend on MPFR and MPC internal implementations details"
-         "(even more than the standard build)"),
         ('gcov', None, "Enable GCC code coverage collection"),
         ('static', None, "Enable static linking compile time options."),
         ('static-dir=', None, "Enable static linking and specify location."),
@@ -29,7 +26,6 @@ class Gmpy2Build(build_ext):
 
     def initialize_options(self):
         build_ext.initialize_options(self)
-        self.fast = False
         self.gcov = False
         self.static = False
         self.static_dir = False
@@ -38,8 +34,6 @@ class Gmpy2Build(build_ext):
     def finalize_options(self):
         build_ext.finalize_options(self)
         self.force = 1
-        if self.fast:
-            _comp_args.append('DFAST=1')
         if self.gcov:
             if ON_WINDOWS:
                 raise ValueError("Cannot enable GCC code coverage on Windows")

--- a/src/gmpy2.h
+++ b/src/gmpy2.h
@@ -312,8 +312,6 @@ typedef struct {
 #endif
 
 #if defined(MS_WIN32) && defined(_MSC_VER)
-   /* so one won't need to link explicitly to gmp.lib...: */
-#  pragma comment(lib,"gmp.lib")
 #  define USE_ALLOCA 1
 #  define inline __inline
 #endif

--- a/src/gmpy2_format.c
+++ b/src/gmpy2_format.c
@@ -59,6 +59,10 @@ GMPy_MPZ_Format(PyObject *self, PyObject *args)
 
     p2 = (unsigned char*)fmt;
     for (p1 = (unsigned char*)fmtcode; *p1 != '\00'; p1++) {
+        if ((size_t)(p2 - (unsigned char*)fmt) >= sizeof(fmt)) {
+            VALUE_ERROR("too long format string");
+            return NULL;
+        }
         if (*p1 == '<' || *p1 == '>' || *p1 == '^') {
             if (seenalign || seensign || seenindicator || seendigits) {
                 VALUE_ERROR("Invalid conversion specification");
@@ -225,6 +229,13 @@ GMPy_MPFR_Format(PyObject *self, PyObject *args)
     *(p2++) = '%';
 
     for (p1 = (unsigned char*)fmtcode; *p1 != '\00'; p1++) {
+        /* Reserve space for precision value, when it's not specified. */
+        if (((size_t)(p2 - mpfrfmt) > sizeof(mpfrfmt) - 30)
+            || ((size_t)(p3 - fmt) >= sizeof(fmt)))
+        {
+            VALUE_ERROR("too long format string");
+            return NULL;
+        }
         if (*p1 == '<' || *p1 == '>' || *p1 == '^') {
             if (seenalign || seensign || seendecimal || seendigits || seenround || seenindicator) {
                 VALUE_ERROR("Invalid conversion specification");
@@ -445,8 +456,8 @@ GMPy_MPC_Format(PyObject *self, PyObject *args)
 {
     PyObject *result = NULL, *tempstr = NULL;
     char *realbuf = 0, *imagbuf = 0, *tempbuf = 0, *fmtcode = 0;
-    char *rfmtptr, *fmtptr;
-    unsigned char *p, *ifmtptr;
+    char *rfmtptr, *fmtptr, *ifmtptr;
+    unsigned char *p;
     char rfmt[100], ifmt[100], fmt[30];
     int rbuflen, ibuflen;
     int seensign = 0, seenalign = 0, seendecimal = 0, seendigits = 0;
@@ -468,12 +479,20 @@ GMPy_MPC_Format(PyObject *self, PyObject *args)
     }
 
     rfmtptr = rfmt;
-    ifmtptr = (unsigned char*)ifmt;
+    ifmtptr = ifmt;
     fmtptr = fmt;
     *(rfmtptr++) = '%';
     *(ifmtptr++) = '%';
 
     for (p = (unsigned char*)fmtcode; *p != '\00'; p++) {
+        /* Reserve space for precision value, when it's not specified. */
+        if (((size_t)(rfmtptr - rfmt) > sizeof(rfmt) - 30)
+            || ((size_t)(ifmtptr - ifmt) > sizeof(ifmt) - 30)
+            || ((size_t)(fmtptr - fmt) >= sizeof(fmt)))
+        {
+            VALUE_ERROR("too long format string");
+            return NULL;
+        }
         if (*p == '<' || *p == '>' || *p == '^') {
             if (seenalign || seensign || seendecimal || seendigits ||
                 seenround || seenstyle || seenindicator)

--- a/src/gmpy2_mpc.h
+++ b/src/gmpy2_mpc.h
@@ -41,10 +41,6 @@ extern "C" {
  * This file is expected to be included from gmpy.h
  */
 
-#if defined(MS_WIN32) && defined(_MSC_VER)
-#  pragma comment(lib,"mpc.lib")
-#endif
-
 static PyTypeObject MPC_Type;
 #define MPC_Check(v) (((PyObject*)v)->ob_type == &MPC_Type)
 

--- a/src/gmpy2_mpfr.h
+++ b/src/gmpy2_mpfr.h
@@ -40,10 +40,6 @@
 extern "C" {
 #endif
 
-#if defined(MS_WIN32) && defined(_MSC_VER)
-#  pragma comment(lib,"mpfr.lib")
-#endif
-
 static PyTypeObject MPFR_Type;
 #define MPFR_Check(v) (((PyObject*)v)->ob_type == &MPFR_Type)
 

--- a/src/gmpy2_mpfr.h
+++ b/src/gmpy2_mpfr.h
@@ -40,11 +40,6 @@
 extern "C" {
 #endif
 
-
-#if !defined(FLT_RADIX) || (FLT_RADIX!=2)
-#   error "FLT_RADIX undefined or != 2, GMPY2 is confused. :("
-#endif
-
 #if defined(MS_WIN32) && defined(_MSC_VER)
 #  pragma comment(lib,"mpfr.lib")
 #endif

--- a/src/gmpy2_mpfr.h
+++ b/src/gmpy2_mpfr.h
@@ -49,60 +49,6 @@ extern "C" {
 #  pragma comment(lib,"mpfr.lib")
 #endif
 
-#ifdef FAST
-
-/* Very bad code ahead. I've copied portions of mpfr-impl.h and
- * hacked them so they work. This code will only be enabled if you
- * specify the --fast option.
- */
-
-#define MPFR_THREAD_ATTR __thread
-__MPFR_DECLSPEC extern MPFR_THREAD_ATTR unsigned int __gmpfr_flags;
-__MPFR_DECLSPEC extern MPFR_THREAD_ATTR mpfr_exp_t   __gmpfr_emin;
-__MPFR_DECLSPEC extern MPFR_THREAD_ATTR mpfr_exp_t   __gmpfr_emax;
-
-/* Flags of __gmpfr_flags */
-#define MPFR_FLAGS_UNDERFLOW 1
-#define MPFR_FLAGS_OVERFLOW 2
-#define MPFR_FLAGS_NAN 4
-#define MPFR_FLAGS_INEXACT 8
-#define MPFR_FLAGS_ERANGE 16
-#define MPFR_FLAGS_DIVBY0 32
-#define MPFR_FLAGS_ALL (MPFR_FLAGS_UNDERFLOW | \
-                        MPFR_FLAGS_OVERFLOW  | \
-                        MPFR_FLAGS_NAN       | \
-                        MPFR_FLAGS_INEXACT   | \
-                        MPFR_FLAGS_ERANGE    | \
-                        MPFR_FLAGS_DIVBY0)
-
-/* Replace some common functions for direct access to the global vars */
-#define mpfr_get_emin() (__gmpfr_emin + 0)
-#define mpfr_get_emax() (__gmpfr_emax + 0)
-
-#define mpfr_clear_flags()      ((void) (__gmpfr_flags = 0))
-#define mpfr_clear_underflow()  ((void) (__gmpfr_flags &= MPFR_FLAGS_ALL ^ MPFR_FLAGS_UNDERFLOW))
-#define mpfr_clear_overflow()   ((void) (__gmpfr_flags &= MPFR_FLAGS_ALL ^ MPFR_FLAGS_OVERFLOW))
-#define mpfr_clear_nanflag()    ((void) (__gmpfr_flags &= MPFR_FLAGS_ALL ^ MPFR_FLAGS_NAN))
-#define mpfr_clear_inexflag()   ((void) (__gmpfr_flags &= MPFR_FLAGS_ALL ^ MPFR_FLAGS_INEXACT))
-#define mpfr_clear_erangeflag() ((void) (__gmpfr_flags &= MPFR_FLAGS_ALL ^ MPFR_FLAGS_ERANGE))
-#define mpfr_clear_divby0()     ((void) (__gmpfr_flags &= MPFR_FLAGS_ALL ^ MPFR_FLAGS_DIVBY0))
-#define mpfr_underflow_p()      ((int) (__gmpfr_flags & MPFR_FLAGS_UNDERFLOW))
-#define mpfr_overflow_p()       ((int) (__gmpfr_flags & MPFR_FLAGS_OVERFLOW))
-#define mpfr_nanflag_p()        ((int) (__gmpfr_flags & MPFR_FLAGS_NAN))
-#define mpfr_inexflag_p()       ((int) (__gmpfr_flags & MPFR_FLAGS_INEXACT))
-#define mpfr_erangeflag_p()     ((int) (__gmpfr_flags & MPFR_FLAGS_ERANGE))
-#define mpfr_divby0_p()         ((int) (__gmpfr_flags & MPFR_FLAGS_DIVBY0))
-
-#define mpfr_check_range(x,t,r) \
- ((((x)->_mpfr_exp) >= __gmpfr_emin && ((x)->_mpfr_exp) <= __gmpfr_emax) \
-  ? ((t) ? (__gmpfr_flags |= MPFR_FLAGS_INEXACT, (t)) : 0)               \
-  : mpfr_check_range(x,t,r))
-
-/* End of the really bad code. Hopefully.
- */
-
-#endif
-
 static PyTypeObject MPFR_Type;
 #define MPFR_Check(v) (((PyObject*)v)->ob_type == &MPFR_Type)
 

--- a/test/test_mpc.py
+++ b/test/test_mpc.py
@@ -229,6 +229,8 @@ def test_mpc_format():
     gmpy2.set_context(gmpy2.context(round=gmpy2.RoundUp))
     assert f'{c:.2f}' == '2.68+0.00j'
 
+    pytest.raises(ValueError, lambda: format(mpc(1), "1" + "0"*70))
+
 
 def test_mpc_repr():
     c = mpc('1.2999999999999999999999999999994-4.7000000000000000000000000000000025j',(100,110))

--- a/test/test_mpfr.py
+++ b/test/test_mpfr.py
@@ -358,6 +358,8 @@ def test_mpfr_format():
     gmpy2.set_context(gmpy2.context(round=gmpy2.RoundUp))
     assert f'{r:.2f}' == '2.68'
 
+    pytest.raises(ValueError, lambda: format(mpfr(1), "1" + "0"*70))
+
 
 def test_mpfr_digits():
     r, r2 = mpfr(5.6), mpfr(5)

--- a/test/test_mpz.py
+++ b/test/test_mpz.py
@@ -666,6 +666,8 @@ def test_mpz_format():
     gmpy2.set_context(gmpy2.ieee(64))
     assert '{:f}'.format(a<<1024) == 'inf'
 
+    raises(ValueError, lambda: format(mpz(1), "1" + "0"*70))
+
 
 def test_mpz_digits():
     z1, z2 = mpz(-3), mpz(15)


### PR DESCRIPTION
* check for buffer overflows of format strings in ``__format__()`` dunders
* drop code, that depends on MPFR/MPC internals
* drop check for FLT_RADIX
* drop pragma's to link with gmp.lib and co
* update cibuildwheel to v4.1.0
* support CPython v3.15
