### PR TITLE
Drop additional constraint for Jacobi symbol

### DIFF
--- a/src/gmpy2_mpz_misc.c
+++ b/src/gmpy2_mpz_misc.c
@@ -1593,7 +1593,7 @@ GMPy_MPZ_Function_PrevPrime(PyObject *self, PyObject *other)
 
 PyDoc_STRVAR(GMPy_doc_mpz_function_jacobi,
 "jacobi($module, x, y, /)\n--\n\n"
-"Return the Jacobi symbol (x|y). y must be odd and >0.");
+"Return the Jacobi symbol (x|y). y must be odd.");
 
 static PyObject *
 GMPy_MPZ_Function_Jacobi(PyObject *self, PyObject *const *args,
@@ -1615,8 +1615,8 @@ GMPy_MPZ_Function_Jacobi(PyObject *self, PyObject *const *args,
         return NULL;
     }
 
-    if (mpz_sgn(tempy->z) <= 0 || mpz_even_p(tempy->z)) {
-        VALUE_ERROR("y must be odd and >0");
+    if (mpz_even_p(tempy->z)) {
+        VALUE_ERROR("y must be odd");
         Py_DECREF((PyObject*)tempx);
         Py_DECREF((PyObject*)tempy);
         return NULL;

--- a/test/test_functions.py
+++ b/test/test_functions.py
@@ -1595,11 +1595,11 @@ def test_iroot_rem():
 
 def test_jacobi():
     pytest.raises(TypeError, lambda: jacobi('a', 10))
-    pytest.raises(ValueError, lambda: jacobi(10,-3))
     pytest.raises(TypeError, lambda: jacobi(3))
     pytest.raises(TypeError, lambda: jacobi())
 
-    assert jacobi(10,3) == 1
+    assert jacobi(10, 3) == 1
+    assert jacobi(10, -3) == 1
 
 
 def test_kronecker():


### PR DESCRIPTION
The GMP only require that second argument is odd, extending definition to (a/-b)=(a/b)*(-1 if a < 0 else 1).  Same seems to be true for Mathematica (JacobiSymbol).